### PR TITLE
Add agent type labels, tool duration, and token usage display

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -22,29 +22,45 @@ const (
 
 // StreamItem represents a single item in the output stream
 type StreamItem struct {
-	Type      StreamItemType
-	SessionID string // which session this belongs to
-	AgentID   string // empty for main session, "abc123" for subagents
-	AgentName string // human-readable name derived from agent type or ID
-	Timestamp time.Time
-	Content   string
-	ToolName  string // for tool_input/tool_output
-	ToolID    string // to correlate input with output
+	Type         StreamItemType
+	SessionID    string // which session this belongs to
+	AgentID      string // empty for main session, "abc123" for subagents
+	AgentName    string // human-readable name derived from agent type or ID
+	Timestamp    time.Time
+	Content      string
+	ToolName     string // for tool_input/tool_output
+	ToolID       string // to correlate input with output
+	DurationMs   int64  // tool execution duration in ms (0 = not available)
+	InputTokens  int64  // usage.input_tokens from assistant messages
+	OutputTokens int64  // usage.output_tokens from assistant messages
 }
 
 // RawMessage represents a line from the JSONL file
 type RawMessage struct {
-	Type      string          `json:"type"`
-	AgentID   string          `json:"agentId,omitempty"`
-	SessionID string          `json:"sessionId"`
-	Timestamp string          `json:"timestamp"`
-	Message   json.RawMessage `json:"message"`
+	Type           string          `json:"type"`
+	AgentID        string          `json:"agentId,omitempty"`
+	SessionID      string          `json:"sessionId"`
+	Timestamp      string          `json:"timestamp"`
+	Message        json.RawMessage `json:"message"`
+	ToolUseResult  json.RawMessage `json:"toolUseResult,omitempty"`
+}
+
+// RawToolUseResult represents the toolUseResult field on user messages
+type RawToolUseResult struct {
+	DurationMs int64 `json:"durationMs"`
 }
 
 // AssistantMessage represents the message field for assistant responses
 type AssistantMessage struct {
 	Role    string         `json:"role"`
 	Content []ContentBlock `json:"content"`
+	Usage   *UsageInfo     `json:"usage,omitempty"`
+}
+
+// UsageInfo represents token usage from assistant messages
+type UsageInfo struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
 }
 
 // ContentBlock represents a single content item in assistant response
@@ -159,6 +175,12 @@ func parseAssistantMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 		}
 	}
 
+	// Attach token usage to the first item only
+	if len(items) > 0 && msg.Usage != nil {
+		items[0].InputTokens = msg.Usage.InputTokens
+		items[0].OutputTokens = msg.Usage.OutputTokens
+	}
+
 	return items
 }
 
@@ -171,6 +193,15 @@ func parseUserMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 		return nil
 	}
 
+	// Parse toolUseResult for duration
+	var durationMs int64
+	if len(raw.ToolUseResult) > 0 {
+		var tur RawToolUseResult
+		if err := json.Unmarshal(raw.ToolUseResult, &tur); err == nil {
+			durationMs = tur.DurationMs
+		}
+	}
+
 	var items []StreamItem
 	agentName := "Main"
 	if raw.AgentID != "" {
@@ -180,12 +211,13 @@ func parseUserMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 	for _, result := range results {
 		if result.Type == "tool_result" {
 			items = append(items, StreamItem{
-				Type:      TypeToolOutput,
-				AgentID:   raw.AgentID,
-				AgentName: agentName,
-				Timestamp: timestamp,
-				Content:   extractToolResultContent(result.Content),
-				ToolID:    result.ToolUseID,
+				Type:       TypeToolOutput,
+				AgentID:    raw.AgentID,
+				AgentName:  agentName,
+				Timestamp:  timestamp,
+				Content:    extractToolResultContent(result.Content),
+				ToolID:     result.ToolUseID,
+				DurationMs: durationMs,
 			})
 		}
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -37,12 +37,12 @@ type StreamItem struct {
 
 // RawMessage represents a line from the JSONL file
 type RawMessage struct {
-	Type           string          `json:"type"`
-	AgentID        string          `json:"agentId,omitempty"`
-	SessionID      string          `json:"sessionId"`
-	Timestamp      string          `json:"timestamp"`
-	Message        json.RawMessage `json:"message"`
-	ToolUseResult  json.RawMessage `json:"toolUseResult,omitempty"`
+	Type          string          `json:"type"`
+	AgentID       string          `json:"agentId,omitempty"`
+	SessionID     string          `json:"sessionId"`
+	Timestamp     string          `json:"timestamp"`
+	Message       json.RawMessage `json:"message"`
+	ToolUseResult json.RawMessage `json:"toolUseResult,omitempty"`
 }
 
 // RawToolUseResult represents the toolUseResult field on user messages

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,19 +22,21 @@ const (
 
 // Model is the main TUI model
 type Model struct {
-	tree         *TreeView
-	stream       *StreamView
-	watcher      *watcher.Watcher
-	focus        Focus
-	showTree     bool
-	width        int
-	height       int
-	treeWidth    int
-	sessionID    string
-	skipHistory  bool
-	pollInterval time.Duration
-	err          error
-	quitting     bool
+	tree              *TreeView
+	stream            *StreamView
+	watcher           *watcher.Watcher
+	focus             Focus
+	showTree          bool
+	width             int
+	height            int
+	treeWidth         int
+	sessionID         string
+	skipHistory       bool
+	pollInterval      time.Duration
+	err               error
+	quitting          bool
+	totalInputTokens  int64
+	totalOutputTokens int64
 }
 
 // NewModel creates a new TUI model
@@ -87,7 +89,8 @@ func (m *Model) initWatcher() tea.Cmd {
 		for _, session := range w.GetSessions() {
 			m.tree.AddSession(session.ID, session.ProjectPath)
 			for agentID := range session.Subagents {
-				m.tree.AddAgent(session.ID, agentID)
+				agentType := session.SubagentTypes[agentID]
+				m.tree.AddAgent(session.ID, agentID, agentType)
 			}
 		}
 
@@ -125,11 +128,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateActivityStatus()
 
 	case streamItemMsg:
-		m.stream.AddItem(parser.StreamItem(msg))
+		item := parser.StreamItem(msg)
+		if item.InputTokens > 0 {
+			m.totalInputTokens += item.InputTokens
+		}
+		if item.OutputTokens > 0 {
+			m.totalOutputTokens += item.OutputTokens
+		}
+		m.stream.AddItem(item)
 		m.stream.SetEnabledFilters(m.tree.GetEnabledFilters())
 
 	case newAgentMsg:
-		m.tree.AddAgent(msg.SessionID, msg.AgentID)
+		m.tree.AddAgent(msg.SessionID, msg.AgentID, msg.AgentType)
 		m.stream.SetEnabledFilters(m.tree.GetEnabledFilters())
 
 	case newSessionMsg:
@@ -391,12 +401,34 @@ func (m *Model) renderHeader() string {
 		}
 	}
 
+	// Token usage display
+	tokenInfo := ""
+	if m.totalInputTokens > 0 || m.totalOutputTokens > 0 {
+		tokenInfo = fmt.Sprintf("│ %s in / %s out",
+			formatTokenCount(m.totalInputTokens),
+			formatTokenCount(m.totalOutputTokens))
+	}
+
 	// Build header - use plain text and apply headerStyle uniformly (like Rust version)
 	// Don't use Width() as it causes truncation on narrow terminals
 	headerText := fmt.Sprintf("%s  │  %s", toggles, sessionInfo)
+	if tokenInfo != "" {
+		headerText += "  " + tokenInfo
+	}
 	header := headerStyle.Render(headerText)
 
 	return header
+}
+
+// formatTokenCount formats token counts for display
+func formatTokenCount(n int64) string {
+	if n < 1000 {
+		return fmt.Sprintf("%d", n)
+	}
+	if n < 1000000 {
+		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
+	}
+	return fmt.Sprintf("%.1fm", float64(n)/1000000.0)
 }
 
 func (m *Model) renderToggle(name string, enabled bool, key string) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -129,6 +129,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case streamItemMsg:
 		item := parser.StreamItem(msg)
+		// Accumulate token usage (includes history — shows total session cost)
 		if item.InputTokens > 0 {
 			m.totalInputTokens += item.InputTokens
 		}

--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -215,7 +215,11 @@ func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
 		b.WriteString(toolInputContentStyle.Render(content))
 
 	case parser.TypeToolOutput:
-		header := toolOutputStyle.Render(toolOutputIcon + " Output")
+		outputLabel := toolOutputIcon + " Output"
+		if item.DurationMs > 0 {
+			outputLabel += " " + formatDuration(item.DurationMs)
+		}
+		header := toolOutputStyle.Render(outputLabel)
 		b.WriteString(fmt.Sprintf("%s%s%s\n", agentName, sep, header))
 		content := s.truncateContent(item.Content, width)
 		b.WriteString(toolOutputContentStyle.Render(content))
@@ -261,6 +265,19 @@ func (s *StreamView) truncateContent(content string, width int) string {
 	}
 
 	return strings.Join(wrapped, "\n")
+}
+
+// formatDuration formats a duration in milliseconds to a human-readable string
+func formatDuration(ms int64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("(%dms)", ms)
+	}
+	secs := float64(ms) / 1000.0
+	if secs < 60 {
+		return fmt.Sprintf("(%.1fs)", secs)
+	}
+	mins := secs / 60.0
+	return fmt.Sprintf("(%.1fm)", mins)
 }
 
 // View renders the stream

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -105,8 +105,10 @@ func (t *TreeView) AddSession(sessionID, projectPath string) *TreeNode {
 	return session
 }
 
-// AddAgent adds a subagent under a session
-func (t *TreeView) AddAgent(sessionID, agentID string) {
+// AddAgent adds a subagent under a session.
+// If agentType is non-empty, it is used as the display name.
+// For compound types like "feature-dev:code-reviewer", only the part after ":" is used.
+func (t *TreeView) AddAgent(sessionID, agentID, agentType string) {
 	// Find the session node
 	var session *TreeNode
 	for _, child := range t.Root.Children {
@@ -127,11 +129,21 @@ func (t *TreeView) AddAgent(sessionID, agentID string) {
 		}
 	}
 
+	displayName := fmt.Sprintf("Agent-%s", agentID[:min(AgentIDDisplayLength, len(agentID))])
+	if agentType != "" {
+		// For compound types like "feature-dev:code-reviewer", use part after ":"
+		if idx := strings.LastIndex(agentType, ":"); idx >= 0 && idx < len(agentType)-1 {
+			displayName = agentType[idx+1:]
+		} else {
+			displayName = agentType
+		}
+	}
+
 	node := &TreeNode{
 		Type:      NodeTypeAgent,
 		ID:        agentID,
 		SessionID: sessionID,
-		Name:      fmt.Sprintf("Agent-%s", agentID[:min(AgentIDDisplayLength, len(agentID))]),
+		Name:      displayName,
 		Enabled:   true,
 		IsActive:  true,
 		Parent:    session,

--- a/internal/tui/tree_test.go
+++ b/internal/tui/tree_test.go
@@ -44,7 +44,7 @@ func TestTreeView_AddSessionDuplicate(t *testing.T) {
 func TestTreeView_AddAgent(t *testing.T) {
 	tv := NewTreeView()
 	tv.AddSession("sess1", "project")
-	tv.AddAgent("sess1", "agent123456789")
+	tv.AddAgent("sess1", "agent123456789", "")
 
 	session := tv.Root.Children[0]
 	if len(session.Children) != 2 {
@@ -65,7 +65,7 @@ func TestTreeView_AddAgent(t *testing.T) {
 func TestTreeView_AddAgentNoSession(t *testing.T) {
 	tv := NewTreeView()
 	// Should not panic when adding agent to non-existent session
-	tv.AddAgent("nonexistent", "agent1")
+	tv.AddAgent("nonexistent", "agent1", "")
 	if len(tv.Root.Children) != 0 {
 		t.Error("should not add anything for non-existent session")
 	}
@@ -74,8 +74,8 @@ func TestTreeView_AddAgentNoSession(t *testing.T) {
 func TestTreeView_AddAgentDuplicate(t *testing.T) {
 	tv := NewTreeView()
 	tv.AddSession("sess1", "project")
-	tv.AddAgent("sess1", "agent1")
-	tv.AddAgent("sess1", "agent1")
+	tv.AddAgent("sess1", "agent1", "")
+	tv.AddAgent("sess1", "agent1", "")
 
 	session := tv.Root.Children[0]
 	if len(session.Children) != 2 {
@@ -107,7 +107,7 @@ func TestTreeView_AddBackgroundTask(t *testing.T) {
 func TestTreeView_AddBackgroundTaskUnderAgent(t *testing.T) {
 	tv := NewTreeView()
 	tv.AddSession("sess1", "project")
-	tv.AddAgent("sess1", "agent1")
+	tv.AddAgent("sess1", "agent1", "")
 	tv.AddBackgroundTask("sess1", "agent1", "toolu_456", "Task: explore", "/path/out.txt", true)
 
 	agent := tv.Root.Children[0].Children[1]
@@ -180,7 +180,7 @@ func TestTreeView_RemoveNonExistent(t *testing.T) {
 func TestTreeView_GetEnabledFilters(t *testing.T) {
 	tv := NewTreeView()
 	tv.AddSession("sess1", "project")
-	tv.AddAgent("sess1", "agent1")
+	tv.AddAgent("sess1", "agent1", "")
 
 	filters := tv.GetEnabledFilters()
 	if len(filters) != 2 {
@@ -222,7 +222,7 @@ func TestTreeView_GetEnabledFiltersDisabled(t *testing.T) {
 func TestTreeView_Navigation(t *testing.T) {
 	tv := NewTreeView()
 	tv.AddSession("sess1", "project")
-	tv.AddAgent("sess1", "agent1")
+	tv.AddAgent("sess1", "agent1", "")
 	// Nodes: session, main, agent = 3 nodes
 
 	if tv.cursor != 0 {
@@ -300,7 +300,7 @@ func TestTreeView_GetSelectedNode(t *testing.T) {
 func TestTreeView_GetSelectedSession(t *testing.T) {
 	tv := NewTreeView()
 	tv.AddSession("sess1", "project")
-	tv.AddAgent("sess1", "agent1")
+	tv.AddAgent("sess1", "agent1", "")
 
 	// At session
 	tv.cursor = 0

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -115,8 +116,9 @@ type Session struct {
 	ProjectPath     string
 	MainFile        string
 	Subagents       map[string]string          // agentID -> file path
+	SubagentTypes   map[string]string          // agentID -> agentType from .meta.json
 	BackgroundTasks map[string]*BackgroundTask // toolID -> task info
-	mu              sync.RWMutex               // protects Subagents and BackgroundTasks maps
+	mu              sync.RWMutex               // protects Subagents, SubagentTypes and BackgroundTasks maps
 }
 
 // BackgroundTask represents a background task launched by an agent
@@ -132,6 +134,7 @@ type BackgroundTask struct {
 type NewAgentMsg struct {
 	SessionID string
 	AgentID   string
+	AgentType string
 }
 
 // NewSessionMsg signals when a new session is discovered
@@ -313,6 +316,7 @@ func (w *Watcher) buildSession(mainFile string) (*Session, error) {
 		ProjectPath:     projectPath,
 		MainFile:        mainFile,
 		Subagents:       make(map[string]string),
+		SubagentTypes:   make(map[string]string),
 		BackgroundTasks: make(map[string]*BackgroundTask),
 	}
 
@@ -322,7 +326,11 @@ func (w *Watcher) buildSession(mainFile string) (*Session, error) {
 		for _, entry := range entries {
 			if strings.HasSuffix(entry.Name(), ".jsonl") {
 				agentID := strings.TrimPrefix(strings.TrimSuffix(entry.Name(), ".jsonl"), "agent-")
-				session.Subagents[agentID] = filepath.Join(subagentDir, entry.Name())
+				jsonlPath := filepath.Join(subagentDir, entry.Name())
+				session.Subagents[agentID] = jsonlPath
+				if agentType := readAgentType(jsonlPath); agentType != "" {
+					session.SubagentTypes[agentID] = agentType
+				}
 			}
 		}
 	}
@@ -950,6 +958,23 @@ func (w *Watcher) handleNewSessionFile(path string) {
 	}
 }
 
+// readAgentType reads the .meta.json file corresponding to a .jsonl path
+// and returns the agentType value. Returns empty string if not available.
+func readAgentType(jsonlPath string) string {
+	metaPath := strings.TrimSuffix(jsonlPath, ".jsonl") + ".meta.json"
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return ""
+	}
+	var meta struct {
+		AgentType string `json:"agentType"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return ""
+	}
+	return meta.AgentType
+}
+
 // handleNewSubagentFile processes discovery of a new subagent JSONL file
 func (w *Watcher) handleNewSubagentFile(path string) {
 	if !strings.HasSuffix(path, ".jsonl") {
@@ -971,18 +996,23 @@ func (w *Watcher) handleNewSubagentFile(path string) {
 		return
 	}
 
+	agentType := readAgentType(path)
+
 	session.mu.Lock()
 	if _, exists := session.Subagents[agentID]; exists {
 		session.mu.Unlock()
 		return
 	}
 	session.Subagents[agentID] = path
+	if agentType != "" {
+		session.SubagentTypes[agentID] = agentType
+	}
 	session.mu.Unlock()
 
 	w.addFileWatch(path, sessionID, agentID)
 
 	select {
-	case w.NewAgent <- NewAgentMsg{SessionID: sessionID, AgentID: agentID}:
+	case w.NewAgent <- NewAgentMsg{SessionID: sessionID, AgentID: agentID, AgentType: agentType}:
 	default:
 	}
 }
@@ -1107,6 +1137,8 @@ func (w *Watcher) checkForNewSubagents(session *Session) {
 			path := filepath.Join(subagentDir, entry.Name())
 
 			// Check and add with write lock to avoid TOCTOU race
+			agentType := readAgentType(path)
+
 			session.mu.Lock()
 			_, exists := session.Subagents[agentID]
 			if exists {
@@ -1114,10 +1146,13 @@ func (w *Watcher) checkForNewSubagents(session *Session) {
 				continue
 			}
 			session.Subagents[agentID] = path
+			if agentType != "" {
+				session.SubagentTypes[agentID] = agentType
+			}
 			session.mu.Unlock()
 
 			select {
-			case w.NewAgent <- NewAgentMsg{SessionID: session.ID, AgentID: agentID}:
+			case w.NewAgent <- NewAgentMsg{SessionID: session.ID, AgentID: agentID, AgentType: agentType}:
 			default:
 			}
 		}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -919,8 +919,9 @@ func (w *Watcher) handleFsWrite(path string) {
 
 	sessionID := ctx.sessionID
 	agentID := ctx.agentID
+	agentType := w.lookupAgentType(sessionID, agentID)
 	w.debounceTimers[path] = time.AfterFunc(DebounceInterval, func() {
-		w.readFile(path, sessionID, agentID)
+		w.readFile(path, sessionID, agentID, agentType)
 		w.debounceMu.Lock()
 		delete(w.debounceTimers, path)
 		w.debounceMu.Unlock()
@@ -956,6 +957,23 @@ func (w *Watcher) handleNewSessionFile(path string) {
 	case w.NewSession <- NewSessionMsg{SessionID: session.ID, ProjectPath: session.ProjectPath}:
 	default:
 	}
+}
+
+// lookupAgentType returns the stored agent type for a given session/agent pair.
+func (w *Watcher) lookupAgentType(sessionID, agentID string) string {
+	if agentID == "" {
+		return ""
+	}
+	w.sessionsMu.RLock()
+	session, exists := w.sessions[sessionID]
+	w.sessionsMu.RUnlock()
+	if !exists {
+		return ""
+	}
+	session.mu.RLock()
+	agentType := session.SubagentTypes[agentID]
+	session.mu.RUnlock()
+	return agentType
 }
 
 // readAgentType reads the .meta.json file corresponding to a .jsonl path
@@ -1258,23 +1276,27 @@ func findPositionForLastNLines(path string, n int) int64 {
 
 func (w *Watcher) readSessionFiles(session *Session) {
 	// Read main file
-	w.readFile(session.MainFile, session.ID, "")
+	w.readFile(session.MainFile, session.ID, "", "")
 
-	// Get snapshot of subagents to avoid holding lock during file reads
+	// Get snapshot of subagents and types to avoid holding lock during file reads
 	session.mu.RLock()
 	subagents := make(map[string]string, len(session.Subagents))
 	for k, v := range session.Subagents {
 		subagents[k] = v
 	}
+	subagentTypes := make(map[string]string, len(session.SubagentTypes))
+	for k, v := range session.SubagentTypes {
+		subagentTypes[k] = v
+	}
 	session.mu.RUnlock()
 
 	// Read subagent files
 	for agentID, path := range subagents {
-		w.readFile(path, session.ID, agentID)
+		w.readFile(path, session.ID, agentID, subagentTypes[agentID])
 	}
 }
 
-func (w *Watcher) readFile(path string, sessionID string, agentID string) {
+func (w *Watcher) readFile(path string, sessionID string, agentID string, agentType string) {
 	file, err := os.Open(path)
 	if err != nil {
 		return
@@ -1312,7 +1334,15 @@ func (w *Watcher) readFile(path string, sessionID string, agentID string) {
 			// Set agent ID from context if not already set
 			if agentID != "" && item.AgentID == "" {
 				item.AgentID = agentID
-				item.AgentName = fmt.Sprintf("Agent-%s", agentID[:min(AgentIDDisplayLength, len(agentID))])
+				if agentType != "" {
+					if idx := strings.LastIndex(agentType, ":"); idx >= 0 && idx < len(agentType)-1 {
+						item.AgentName = agentType[idx+1:]
+					} else {
+						item.AgentName = agentType
+					}
+				} else {
+					item.AgentName = fmt.Sprintf("Agent-%s", agentID[:min(AgentIDDisplayLength, len(agentID))])
+				}
 			}
 
 			select {


### PR DESCRIPTION
## Summary

- **Agent type labels**: Parse `.meta.json` to show agent types (e.g., "Explore", "code-reviewer") instead of generic "Agent-abc1234" in both tree and stream views
- **Tool execution duration**: Show `toolUseResult.durationMs` on output headers (e.g., "(1.2s)", "(45ms)")
- **Token usage tracking**: Accumulate and display cumulative input/output token counts in the header bar (e.g., "12.3k in / 4.5k out")

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go build .` — compiles cleanly
- [ ] Manual test: verify agent types display correctly in tree and stream
- [ ] Manual test: verify tool duration appears on output headers
- [ ] Manual test: verify token counts accumulate in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)