### PR TITLE
Add active window and max sessions flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ claude-esp
 | `-s <ID>`  | Watch a specific session by ID                |
 | `-n`       | Start from newest (skip history, live only)   |
 | `-l`       | List recent sessions                          |
-| `-a`       | List active sessions (modified in last 5 min) |
+| `-a`       | List active sessions                          |
 | `-p <ms>`  | Poll interval in ms (fallback mode only, default 500) |
+| `-w <dur>` | Active window duration (default `5m`, e.g. `30s`, `2m`) |
+| `-m <N>`   | Max sessions to show in tree (default 0 = unlimited) |
 | `-v`       | Show version                                  |
 | `-h`       | Show help                                     |
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -33,6 +33,8 @@ type Model struct {
 	sessionID         string
 	skipHistory       bool
 	pollInterval      time.Duration
+	activeWindow      time.Duration
+	maxSessions       int
 	err               error
 	quitting          bool
 	totalInputTokens  int64
@@ -40,7 +42,7 @@ type Model struct {
 }
 
 // NewModel creates a new TUI model
-func NewModel(sessionID string, skipHistory bool, pollInterval time.Duration) *Model {
+func NewModel(sessionID string, skipHistory bool, pollInterval time.Duration, activeWindow time.Duration, maxSessions int) *Model {
 	return &Model{
 		tree:         NewTreeView(),
 		stream:       NewStreamView(),
@@ -50,6 +52,8 @@ func NewModel(sessionID string, skipHistory bool, pollInterval time.Duration) *M
 		sessionID:    sessionID,
 		skipHistory:  skipHistory,
 		pollInterval: pollInterval,
+		activeWindow: activeWindow,
+		maxSessions:  maxSessions,
 	}
 }
 
@@ -74,7 +78,7 @@ func (m *Model) Init() tea.Cmd {
 
 func (m *Model) initWatcher() tea.Cmd {
 	return func() tea.Msg {
-		w, err := watcher.New(m.sessionID, m.pollInterval)
+		w, err := watcher.New(m.sessionID, m.pollInterval, m.activeWindow, m.maxSessions)
 		if err != nil {
 			return errMsg(err)
 		}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -178,6 +178,7 @@ type Watcher struct {
 	cancel            context.CancelFunc
 	watchActive       atomic.Bool   // if true, only watch recently modified sessions
 	activeWindow      time.Duration // how recent is "active"
+	maxSessions       int           // max sessions to track (0=unlimited)
 	skipHistory       atomic.Bool   // if true, start from end of files (live only)
 
 	// fsnotify fields
@@ -191,7 +192,9 @@ type Watcher struct {
 
 // New creates a new watcher for active sessions.
 // If pollInterval is 0, DefaultPollInterval is used.
-func New(sessionID string, pollInterval time.Duration) (*Watcher, error) {
+// If activeWindow is 0, DefaultActiveWindow is used.
+// If maxSessions is 0, no limit is applied.
+func New(sessionID string, pollInterval time.Duration, activeWindow time.Duration, maxSessions int) (*Watcher, error) {
 	claudeDir, err := getClaudeProjectsDir()
 	if err != nil {
 		return nil, err
@@ -201,6 +204,9 @@ func New(sessionID string, pollInterval time.Duration) (*Watcher, error) {
 
 	if pollInterval <= 0 {
 		pollInterval = DefaultPollInterval
+	}
+	if activeWindow <= 0 {
+		activeWindow = DefaultActiveWindow
 	}
 
 	w := &Watcher{
@@ -215,7 +221,8 @@ func New(sessionID string, pollInterval time.Duration) (*Watcher, error) {
 		NewBackgroundTask: make(chan NewBackgroundTaskMsg, ErrorChannelBuffer),
 		ctx:               ctx,
 		cancel:            cancel,
-		activeWindow:      DefaultActiveWindow,
+		activeWindow:      activeWindow,
+		maxSessions:       maxSessions,
 		fileContexts:      make(map[string]fileCtx),
 		debounceTimers:    make(map[string]*time.Timer),
 	}
@@ -340,8 +347,16 @@ func (w *Watcher) buildSession(mainFile string) (*Session, error) {
 	return session, nil
 }
 
+// discoveredSession is a temporary struct for sorting by modification time
+type discoveredSession struct {
+	session *Session
+	modTime time.Time
+}
+
 func (w *Watcher) discoverActiveSessions() error {
 	now := time.Now()
+
+	var discovered []discoveredSession
 
 	err := filepath.Walk(w.claudeDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -361,9 +376,23 @@ func (w *Watcher) discoverActiveSessions() error {
 			return nil
 		}
 
-		w.sessions[session.ID] = session
+		discovered = append(discovered, discoveredSession{session: session, modTime: info.ModTime()})
 		return nil
 	})
+
+	// Sort by most recent first and apply max-sessions cap
+	if len(discovered) > 1 {
+		sort.Slice(discovered, func(i, j int) bool {
+			return discovered[i].modTime.After(discovered[j].modTime)
+		})
+	}
+	if w.maxSessions > 0 && len(discovered) > w.maxSessions {
+		discovered = discovered[:w.maxSessions]
+	}
+
+	for _, d := range discovered {
+		w.sessions[d.session.ID] = d.session
+	}
 
 	return err
 }
@@ -1095,6 +1124,9 @@ func (w *Watcher) handleNewToolResultFile(path string) {
 func (w *Watcher) checkForNewSessions() {
 	now := time.Now()
 
+	// Collect candidates first, then decide which to add
+	var candidates []discoveredSession
+
 	filepath.Walk(w.claudeDir, func(path string, info os.FileInfo, err error) error {
 		// Check for context cancellation to avoid goroutine leak
 		select {
@@ -1118,30 +1150,55 @@ func (w *Watcher) checkForNewSessions() {
 		basename := filepath.Base(path)
 		id := strings.TrimSuffix(basename, ".jsonl")
 
-		// Check and add with write lock to avoid TOCTOU race
-		w.sessionsMu.Lock()
+		w.sessionsMu.RLock()
 		_, exists := w.sessions[id]
+		w.sessionsMu.RUnlock()
+
 		if exists {
-			w.sessionsMu.Unlock()
 			return nil
 		}
 
 		session, err := w.buildSession(path)
 		if err != nil {
-			w.sessionsMu.Unlock()
 			return nil
 		}
 
-		w.sessions[session.ID] = session
+		candidates = append(candidates, discoveredSession{session: session, modTime: info.ModTime()})
+		return nil
+	})
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	// Sort candidates by most recent first
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+
+	w.sessionsMu.Lock()
+	for _, c := range candidates {
+		// Enforce max-sessions cap
+		if w.maxSessions > 0 && len(w.sessions) >= w.maxSessions {
+			break
+		}
+
+		if _, exists := w.sessions[c.session.ID]; exists {
+			continue
+		}
+
+		w.sessions[c.session.ID] = c.session
 		w.sessionsMu.Unlock()
 
 		// Notify about new session
 		select {
-		case w.NewSession <- NewSessionMsg{SessionID: session.ID, ProjectPath: session.ProjectPath}:
+		case w.NewSession <- NewSessionMsg{SessionID: c.session.ID, ProjectPath: c.session.ProjectPath}:
 		default:
 		}
-		return nil
-	})
+
+		w.sessionsMu.Lock()
+	}
+	w.sessionsMu.Unlock()
 }
 
 func (w *Watcher) checkForNewSubagents(session *Session) {

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ func main() {
 	listActive := flag.Bool("a", false, "List active sessions (modified in last 5 min)")
 	skipHistory := flag.Bool("n", false, "Start from newest (skip history, live only)")
 	pollMs := flag.Int("p", 500, "Poll interval in milliseconds (min 100)")
+	activeWindowStr := flag.String("w", "5m", "Active window duration (e.g. 30s, 2m, 5m)")
+	maxSessions := flag.Int("m", 0, "Max sessions to show in tree (0=unlimited)")
 	showVersion := flag.Bool("v", false, "Show version")
 	showHelp := flag.Bool("h", false, "Show help")
 
@@ -49,14 +51,21 @@ func main() {
 		return
 	}
 
+	// Parse active window duration
+	activeWindow, err := time.ParseDuration(*activeWindowStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid active window duration %q: %v\n", *activeWindowStr, err)
+		os.Exit(1)
+	}
+
 	if *listActive {
-		sessions, err := watcher.ListActiveSessions(5 * time.Minute)
+		sessions, err := watcher.ListActiveSessions(activeWindow)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 		if len(sessions) == 0 {
-			fmt.Println("No active sessions (none modified in last 5 minutes)")
+			fmt.Printf("No active sessions (none modified in last %s)\n", activeWindow)
 			return
 		}
 		fmt.Println("Active sessions:")
@@ -94,7 +103,7 @@ func main() {
 	}
 
 	// Run TUI
-	model := tui.NewModel(*sessionID, *skipHistory, pollInterval)
+	model := tui.NewModel(*sessionID, *skipHistory, pollInterval, activeWindow, *maxSessions)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	if _, err := p.Run(); err != nil {
@@ -125,9 +134,11 @@ USAGE:
 OPTIONS:
     -s <ID>     Watch a specific session by ID
     -l          List recent sessions
-    -a          List active sessions (modified in last 5 min)
+    -a          List active sessions
     -n          Start from newest (skip history, live only)
     -p <ms>     Poll interval in ms, fallback mode only (default 500, min 100)
+    -w <dur>    Active window duration (default 5m, e.g. 30s, 2m, 10m)
+    -m <N>      Max sessions to show in tree (default 0=unlimited)
     -v          Show version
     -h          Show this help
 


### PR DESCRIPTION
## Summary

Addresses #5 (thanks @mike-lsadigital for the detailed feature request!)

- **`-w <duration>`**: Configurable active window (default `5m`). Controls how recent a session must be to appear in the tree. Set to e.g. `30s` to hide sleeping sessions without manual cleanup.
- **`-m <N>`**: Cap sessions shown in tree (default `0` = unlimited). Sessions are sorted by most recent activity, so only the N most active are kept.

Both flags apply to initial session discovery and ongoing auto-discovery. Option D (auto-collapse sleeping sessions) is tracked separately for a future PR.

## Test plan

- [x] `go build` / `go test ./...` pass
- [ ] `claude-esp -w 30s` — verify only very recently active sessions appear
- [ ] `claude-esp -m 2` — verify at most 2 sessions in tree
- [ ] `claude-esp -a -w 1m` — verify listing respects custom window
- [ ] `claude-esp -h` — verify new flags documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)