### PR TITLE
Fix in-process subagents not appearing (recursive directory scan)

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -370,3 +370,90 @@ func buildAssistantLine(t *testing.T, toolName, toolID string, inputJSON json.Ra
 	}
 	return string(data)
 }
+
+func TestParseLine_TokenUsageInAssistantMessage(t *testing.T) {
+	// Test that usage data is correctly extracted from assistant messages
+	line := `{"type":"assistant","timestamp":"2025-01-01T12:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"hello world"}],"usage":{"input_tokens":123,"output_tokens":456}}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	item := items[0]
+	if item.InputTokens != 123 {
+		t.Errorf("InputTokens = %d, want 123", item.InputTokens)
+	}
+	if item.OutputTokens != 456 {
+		t.Errorf("OutputTokens = %d, want 456", item.OutputTokens)
+	}
+}
+
+func TestParseLine_MultipleBlocks_TokensOnFirstBlock(t *testing.T) {
+	// When an assistant message has multiple content blocks, tokens should be
+	// attached to the FIRST item only (not duplicated across all blocks)
+	line := `{"type":"assistant","timestamp":"2025-01-01T12:00:00Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"I think"},{"type":"text","text":"I respond"}],"usage":{"input_tokens":100,"output_tokens":200}}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	// First item (thinking) should have token data
+	if items[0].InputTokens != 100 {
+		t.Errorf("items[0].InputTokens = %d, want 100", items[0].InputTokens)
+	}
+	if items[0].OutputTokens != 200 {
+		t.Errorf("items[0].OutputTokens = %d, want 200", items[0].OutputTokens)
+	}
+
+	// Second item (text) should NOT have token data
+	if items[1].InputTokens != 0 {
+		t.Errorf("items[1].InputTokens = %d, want 0 (tokens only on first item)", items[1].InputTokens)
+	}
+	if items[1].OutputTokens != 0 {
+		t.Errorf("items[1].OutputTokens = %d, want 0 (tokens only on first item)", items[1].OutputTokens)
+	}
+}
+
+func TestParseLine_NoUsageInMessage(t *testing.T) {
+	// Test that missing usage data results in 0 tokens
+	line := `{"type":"assistant","timestamp":"2025-01-01T12:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	item := items[0]
+	if item.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0", item.InputTokens)
+	}
+	if item.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0", item.OutputTokens)
+	}
+}
+
+func TestParseLine_UserMessageHasNoTokens(t *testing.T) {
+	// User messages should never have token data (they are not in the Anthropic API response)
+	line := `{"type":"user","timestamp":"2025-01-01T12:00:00Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_abc","content":"result data"}],"usage":{"input_tokens":999,"output_tokens":999}}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	item := items[0]
+	// Even if usage is in the JSON, it should be ignored for user messages
+	if item.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0 (user messages don't have usage)", item.InputTokens)
+	}
+	if item.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0 (user messages don't have usage)", item.OutputTokens)
+	}
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1028,6 +1028,20 @@ func (w *Watcher) handleNewSessionFile(path string) {
 	case w.NewSession <- NewSessionMsg{SessionID: session.ID, ProjectPath: session.ProjectPath}:
 	default:
 	}
+
+	// buildSession may have found subagents that already existed on disk.
+	// Emit NewAgentMsg for each so the TUI shows them. Without this, the
+	// idempotency check in handleNewSubagentFile would suppress the message
+	// (the agent is already in session.Subagents but the TUI was never told).
+	session.mu.RLock()
+	for agentID := range session.Subagents {
+		agentType := session.SubagentTypes[agentID]
+		select {
+		case w.NewAgent <- NewAgentMsg{SessionID: session.ID, AgentID: agentID, AgentType: agentType}:
+		default:
+		}
+	}
+	session.mu.RUnlock()
 }
 
 // lookupAgentType returns the stored agent type for a given session/agent pair.

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -940,6 +940,11 @@ func (w *Watcher) handleFsCreate(path string) {
 // created before the fsnotify watch was established. This closes the race window
 // where in-process agents write files between directory creation and watch setup.
 // All discovery handlers are idempotent, so duplicate calls are safe no-ops.
+//
+// When a parent directory (e.g. <sessionID>/) and its children (e.g. subagents/)
+// are created simultaneously (mkdir -p style), the CREATE event for the child
+// directory fires before we add a watch on the parent, so it is lost. Recursing
+// into subdirectories here ensures we add watches and scan those children too.
 func (w *Watcher) scanNewDirectory(path string) {
 	entries, err := os.ReadDir(path)
 	if err != nil {
@@ -948,12 +953,15 @@ func (w *Watcher) scanNewDirectory(path string) {
 
 	base := filepath.Base(path)
 	for _, entry := range entries {
+		fullPath := filepath.Join(path, entry.Name())
 		if entry.IsDir() {
+			// Add a watch and recurse: the CREATE event for this subdirectory
+			// may have been lost if it was created before the parent was watched.
+			w.fsWatcher.Add(fullPath)
+			w.scanNewDirectory(fullPath)
 			continue
 		}
 		name := entry.Name()
-		fullPath := filepath.Join(path, name)
-
 		switch {
 		case base == "subagents" && strings.HasSuffix(name, ".jsonl"):
 			w.handleNewSubagentFile(fullPath)


### PR DESCRIPTION
## Root Cause — Two bugs, not one

Follow-up to #7 / v0.4.6. After investigation and testing, there were two separate issues:

### Bug 1: `scanNewDirectory` not recursive

When Claude creates the session directory tree (`<sessionID>/subagents/`) in a single operation, the sequence is:

1. `<sessionID>/` created → fsnotify CREATE fires (parent `<project>/` is watched)
2. `<sessionID>/subagents/` created → CREATE fires **but `<sessionID>/` is not yet watched**, so this event is lost
3. We process the `<sessionID>/` CREATE: add watch + call `scanNewDirectory`
4. `scanNewDirectory` finds `subagents/` but **skips it** (`if entry.IsDir() { continue }`)
5. `subagents/` is never watched → files inside are invisible

**Fix:** Make `scanNewDirectory` recursive — when it encounters a subdirectory, add a watch and recurse in.

### Bug 2: `handleNewSessionFile` silently drops pre-existing subagents

When a new session file is discovered:
1. `buildSession` scans `subagents/` and adds found agents to `session.Subagents`
2. Only `NewSessionMsg` is sent — **no `NewAgentMsg`** for the found subagents
3. The TUI adds the session + Main node but never hears about the agents
4. When `scanNewDirectory` later calls `handleNewSubagentFile`, the **idempotency check** (`if _, exists := session.Subagents[agentID]`) returns early — again, no `NewAgentMsg`

**Fix:** After emitting `NewSessionMsg`, emit `NewAgentMsg` for each subagent `buildSession` already found.

Both bugs were confirmed with a test: creating a fresh session dir tree + subagent file atomically showed only Main without the fix, and both session + agent with the fix.

Fixes #9 — thanks @yutohabaxmusic for the thorough follow-up!

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Manual: `mkdir -p <sessionID>/subagents && echo ... > agent.jsonl` → agent appears in tree immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)