### PR TITLE
Modernize JSONL parsing + auto-collapse sleeping sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ claude-esp
 | `-p <ms>`  | Poll interval in ms (fallback mode only, default 500) |
 | `-w <dur>` | Active window duration (default `5m`, e.g. `30s`, `2m`) |
 | `-m <N>`   | Max sessions to show in tree (default 0 = unlimited) |
+| `-c <dur>` | Auto-collapse sessions inactive ≥ dur (default 0 = disabled, e.g. `2m`) |
 | `-v`       | Show version                                  |
 | `-h`       | Show help                                     |
 
@@ -113,11 +114,24 @@ claude-esp -l
 | `A`       | Toggle auto-discovery of new sessions     |
 | `tab`     | Switch focus between tree and stream      |
 | `j/k/↑/↓` | Navigate tree or scroll stream            |
-| `space`   | Toggle selected item in tree              |
+| `space`   | On session: collapse/expand (pins on manual expand) · On agent: toggle visibility |
 | `s`       | Solo selected session/agent (toggle)      |
 | `enter`   | Load background task output (when selected)|
 | `g/G`     | Go to top/bottom of stream                |
 | `q`       | Quit                                      |
+
+## Auto-Collapse
+
+Run with `-c 2m` to automatically collapse sessions that have been idle for 2
+minutes. Collapsed sessions show `▸` instead of `▾` in the tree and display the
+count of hidden subagents (e.g. `📂▸ my-session (+2)`). Children of collapsed
+sessions are also filtered out of the stream pane — the whole point is to stop
+sleeping sessions from dominating your view.
+
+Press `space` on a collapsed session to expand it manually. Manual expansion
+**pins** the session — it won't auto-collapse again until it wakes up (receives
+new activity) and then goes idle once more. Press `s` to solo a session; if
+it's collapsed, Solo force-expands and pins it so you can see its output.
 
 ## How It Works
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -11,10 +11,12 @@ import (
 type StreamItemType string
 
 const (
-	TypeThinking   StreamItemType = "thinking"
-	TypeToolInput  StreamItemType = "tool_input"
-	TypeToolOutput StreamItemType = "tool_output"
-	TypeText       StreamItemType = "text"
+	TypeThinking     StreamItemType = "thinking"
+	TypeToolInput    StreamItemType = "tool_input"
+	TypeToolOutput   StreamItemType = "tool_output"
+	TypeText         StreamItemType = "text"
+	TypeTurnMarker   StreamItemType = "turn_marker"   // turn boundary + duration (system.turn_duration)
+	TypeSessionTitle StreamItemType = "session_title" // session label update (agent-name / custom-title)
 
 	// AgentIDDisplayLength is how many chars of agent ID to show in display name
 	AgentIDDisplayLength = 7
@@ -22,27 +24,36 @@ const (
 
 // StreamItem represents a single item in the output stream
 type StreamItem struct {
-	Type         StreamItemType
-	SessionID    string // which session this belongs to
-	AgentID      string // empty for main session, "abc123" for subagents
-	AgentName    string // human-readable name derived from agent type or ID
-	Timestamp    time.Time
-	Content      string
-	ToolName     string // for tool_input/tool_output
-	ToolID       string // to correlate input with output
-	DurationMs   int64  // tool execution duration in ms (0 = not available)
-	InputTokens  int64  // usage.input_tokens from assistant messages
-	OutputTokens int64  // usage.output_tokens from assistant messages
+	Type                StreamItemType
+	SessionID           string // which session this belongs to
+	AgentID             string // empty for main session, "abc123" for subagents
+	AgentName           string // human-readable name derived from agent type or ID
+	Timestamp           time.Time
+	Content             string
+	ToolName            string // for tool_input/tool_output
+	ToolID              string // to correlate input with output
+	DurationMs          int64  // tool execution duration in ms (0 = not available)
+	InputTokens         int64  // usage.input_tokens from assistant messages
+	OutputTokens        int64  // usage.output_tokens from assistant messages
+	CacheCreationTokens int64  // usage.cache_creation_input_tokens
+	CacheReadTokens     int64  // usage.cache_read_input_tokens
 }
 
 // RawMessage represents a line from the JSONL file
 type RawMessage struct {
 	Type          string          `json:"type"`
+	Subtype       string          `json:"subtype,omitempty"`
 	AgentID       string          `json:"agentId,omitempty"`
 	SessionID     string          `json:"sessionId"`
 	Timestamp     string          `json:"timestamp"`
+	DurationMs    int64           `json:"durationMs,omitempty"`
+	MessageCount  int             `json:"messageCount,omitempty"`
 	Message       json.RawMessage `json:"message"`
 	ToolUseResult json.RawMessage `json:"toolUseResult,omitempty"`
+	// AgentTitle and CustomTitle carry session-level labels on type="agent-name"
+	// and type="custom-title" lines respectively.
+	AgentTitle  string `json:"agentName,omitempty"`
+	CustomTitle string `json:"customTitle,omitempty"`
 }
 
 // RawToolUseResult represents the toolUseResult field on user messages
@@ -59,8 +70,10 @@ type AssistantMessage struct {
 
 // UsageInfo represents token usage from assistant messages
 type UsageInfo struct {
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
 }
 
 // ContentBlock represents a single content item in assistant response
@@ -89,14 +102,22 @@ type ToolResult struct {
 
 // ToolInput represents the input field for various tools
 type ToolInput struct {
-	Command     string `json:"command,omitempty"`
-	Description string `json:"description,omitempty"`
-	Pattern     string `json:"pattern,omitempty"`
-	Path        string `json:"path,omitempty"`
-	FilePath    string `json:"file_path,omitempty"`
-	Content     string `json:"content,omitempty"`
-	Prompt      string `json:"prompt,omitempty"`
-	Query       string `json:"query,omitempty"`
+	Command      string `json:"command,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Pattern      string `json:"pattern,omitempty"`
+	Path         string `json:"path,omitempty"`
+	FilePath     string `json:"file_path,omitempty"`
+	Content      string `json:"content,omitempty"`
+	Prompt       string `json:"prompt,omitempty"`
+	Query        string `json:"query,omitempty"`
+	Skill        string `json:"skill,omitempty"`
+	Args         string `json:"args,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	DelaySeconds int64  `json:"delaySeconds,omitempty"`
+	Subject      string `json:"subject,omitempty"`
+	TaskID       string `json:"taskId,omitempty"`
+	TaskIDSnake  string `json:"task_id,omitempty"`
+	Cron         string `json:"cron,omitempty"`
 }
 
 // ParseLine parses a single JSONL line and returns stream items
@@ -125,9 +146,50 @@ func ParseLine(line string) ([]StreamItem, error) {
 		items = parseAssistantMessage(raw, timestamp)
 	case "user":
 		items = parseUserMessage(raw, timestamp)
+	case "system":
+		items = parseSystemMessage(raw, timestamp)
+	case "agent-name":
+		items = parseSessionTitle(raw, timestamp, raw.AgentTitle)
+	case "custom-title":
+		items = parseSessionTitle(raw, timestamp, raw.CustomTitle)
 	}
 
 	return items, nil
+}
+
+// parseSessionTitle emits a TypeSessionTitle item carrying a human-readable
+// label for the session. Both type="agent-name" (Claude's auto-generated
+// title) and type="custom-title" (user-set) map to this.
+func parseSessionTitle(raw RawMessage, timestamp time.Time, title string) []StreamItem {
+	if title == "" {
+		return nil
+	}
+	return []StreamItem{{
+		Type:      TypeSessionTitle,
+		SessionID: raw.SessionID,
+		Timestamp: timestamp,
+		Content:   title,
+	}}
+}
+
+// parseSystemMessage handles system-type JSONL lines. Currently surfaces only
+// subtype=turn_duration (emitted when a full assistant turn finishes) as a
+// subtle marker in the stream. Other subtypes are intentionally dropped.
+func parseSystemMessage(raw RawMessage, timestamp time.Time) []StreamItem {
+	if raw.Subtype != "turn_duration" {
+		return nil
+	}
+	agentName := "Main"
+	if raw.AgentID != "" {
+		agentName = fmt.Sprintf("Agent-%s", raw.AgentID[:min(AgentIDDisplayLength, len(raw.AgentID))])
+	}
+	return []StreamItem{{
+		Type:       TypeTurnMarker,
+		AgentID:    raw.AgentID,
+		AgentName:  agentName,
+		Timestamp:  timestamp,
+		DurationMs: raw.DurationMs,
+	}}
 }
 
 func parseAssistantMessage(raw RawMessage, timestamp time.Time) []StreamItem {
@@ -172,7 +234,7 @@ func parseAssistantMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 				AgentName: agentName,
 				Timestamp: timestamp,
 				Content:   content,
-				ToolName:  block.Name,
+				ToolName:  PrettyToolName(block.Name),
 				ToolID:    block.ID,
 			})
 		}
@@ -182,6 +244,8 @@ func parseAssistantMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 	if len(items) > 0 && msg.Usage != nil {
 		items[0].InputTokens = msg.Usage.InputTokens
 		items[0].OutputTokens = msg.Usage.OutputTokens
+		items[0].CacheCreationTokens = msg.Usage.CacheCreationInputTokens
+		items[0].CacheReadTokens = msg.Usage.CacheReadInputTokens
 	}
 
 	return items
@@ -293,10 +357,60 @@ func formatToolInput(toolName string, inputRaw json.RawMessage) string {
 		return input.Prompt
 	case "WebSearch":
 		return input.Query
-	case "Task":
+	case "Task", "Agent":
+		// "Task" is the legacy name; "Agent" is current (Claude Code 2.x).
+		if input.Description != "" {
+			return input.Description
+		}
 		return input.Prompt
+	case "Skill":
+		if input.Args != "" {
+			return fmt.Sprintf("%s — %s", input.Skill, input.Args)
+		}
+		return input.Skill
+	case "ToolSearch":
+		return input.Query
+	case "ScheduleWakeup":
+		if input.Reason != "" {
+			return input.Reason
+		}
+		if input.DelaySeconds > 0 {
+			return fmt.Sprintf("delay %ds", input.DelaySeconds)
+		}
+		return string(inputRaw)
+	case "TaskCreate":
+		return input.Subject
+	case "TaskUpdate":
+		if input.TaskID != "" {
+			return fmt.Sprintf("task %s", input.TaskID)
+		}
+		return string(inputRaw)
+	case "TaskStop":
+		return input.TaskIDSnake
+	case "EnterPlanMode":
+		return "(enter plan mode)"
+	case "ExitPlanMode":
+		return "(exit plan mode)"
+	case "CronCreate":
+		if input.Cron != "" && input.Prompt != "" {
+			return fmt.Sprintf("%s: %s", input.Cron, input.Prompt)
+		}
+		return string(inputRaw)
 	default:
-		// Return raw JSON for unknown tools
 		return string(inputRaw)
 	}
+}
+
+// PrettyToolName returns a display-friendly version of a tool name.
+// Long MCP names like mcp__plugin_context7_context7__query-docs are shortened
+// to mcp:query-docs; other names are returned unchanged.
+func PrettyToolName(name string) string {
+	if !strings.HasPrefix(name, "mcp__") {
+		return name
+	}
+	idx := strings.LastIndex(name, "__")
+	if idx <= len("mcp__")-2 || idx == len(name)-2 {
+		return name
+	}
+	return "mcp:" + name[idx+2:]
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -266,13 +266,62 @@ func TestParseLine_EmptyThinking(t *testing.T) {
 }
 
 func TestParseLine_UnknownType(t *testing.T) {
-	line := `{"type":"system","timestamp":"2025-01-01T12:00:00Z","message":{}}`
+	// System messages with unrecognized subtypes should be silently dropped.
+	line := `{"type":"system","subtype":"something_else","timestamp":"2025-01-01T12:00:00Z","message":{}}`
 	items, err := ParseLine(line)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(items) != 0 {
-		t.Errorf("expected 0 items for unknown type, got %d", len(items))
+		t.Errorf("expected 0 items for unknown system subtype, got %d", len(items))
+	}
+}
+
+func TestParseLine_SessionTitleAgentName(t *testing.T) {
+	line := `{"type":"agent-name","agentName":"auto-collapse-feature","sessionId":"sess-1"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 title item, got %d", len(items))
+	}
+	if items[0].Type != TypeSessionTitle {
+		t.Errorf("type = %q, want %q", items[0].Type, TypeSessionTitle)
+	}
+	if items[0].Content != "auto-collapse-feature" {
+		t.Errorf("content = %q, want auto-collapse-feature", items[0].Content)
+	}
+	if items[0].SessionID != "sess-1" {
+		t.Errorf("sessionID = %q, want sess-1", items[0].SessionID)
+	}
+}
+
+func TestParseLine_SessionTitleCustomTitle(t *testing.T) {
+	line := `{"type":"custom-title","customTitle":"my-custom-label","sessionId":"sess-2"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Content != "my-custom-label" {
+		t.Fatalf("expected my-custom-label, got %+v", items)
+	}
+}
+
+func TestParseLine_TurnDuration(t *testing.T) {
+	line := `{"type":"system","subtype":"turn_duration","timestamp":"2025-01-01T12:00:00Z","durationMs":41751,"messageCount":42,"sessionId":"abc"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 turn marker, got %d", len(items))
+	}
+	if items[0].Type != TypeTurnMarker {
+		t.Errorf("type = %q, want %q", items[0].Type, TypeTurnMarker)
+	}
+	if items[0].DurationMs != 41751 {
+		t.Errorf("duration = %d, want 41751", items[0].DurationMs)
 	}
 }
 
@@ -291,6 +340,20 @@ func TestFormatToolInput(t *testing.T) {
 		{"Glob no path", "Glob", `{"pattern":"*.go"}`, "*.go"},
 		{"Grep with path", "Grep", `{"pattern":"TODO","path":"/src"}`, "/TODO/ in /src"},
 		{"Grep no path", "Grep", `{"pattern":"TODO"}`, "/TODO/"},
+		{"Agent with desc", "Agent", `{"description":"audit deps","prompt":"check all deps"}`, "audit deps"},
+		{"Agent prompt fallback", "Agent", `{"prompt":"do a thing"}`, "do a thing"},
+		{"Task legacy alias", "Task", `{"description":"legacy task"}`, "legacy task"},
+		{"Skill with args", "Skill", `{"skill":"beads:create","args":"--title x"}`, "beads:create — --title x"},
+		{"Skill no args", "Skill", `{"skill":"beads:list"}`, "beads:list"},
+		{"ToolSearch", "ToolSearch", `{"query":"select:Read","max_results":1}`, "select:Read"},
+		{"ScheduleWakeup reason", "ScheduleWakeup", `{"delaySeconds":90,"reason":"watching build"}`, "watching build"},
+		{"ScheduleWakeup delay only", "ScheduleWakeup", `{"delaySeconds":90}`, "delay 90s"},
+		{"TaskCreate", "TaskCreate", `{"subject":"write docs","activeForm":"writing"}`, "write docs"},
+		{"TaskUpdate", "TaskUpdate", `{"taskId":"42","status":"in_progress"}`, "task 42"},
+		{"TaskStop", "TaskStop", `{"task_id":"abc123"}`, "abc123"},
+		{"EnterPlanMode", "EnterPlanMode", `{}`, "enter plan mode"},
+		{"ExitPlanMode", "ExitPlanMode", `{}`, "exit plan mode"},
+		{"CronCreate", "CronCreate", `{"cron":"*/5 * * * *","prompt":"ping","recurring":true}`, "*/5 * * * *"},
 		{"Unknown tool", "CustomTool", `{"foo":"bar"}`, `"foo"`},
 		{"Invalid JSON", "Bash", `not json`, "not json"},
 	}
@@ -435,6 +498,63 @@ func TestParseLine_NoUsageInMessage(t *testing.T) {
 	}
 	if item.OutputTokens != 0 {
 		t.Errorf("OutputTokens = %d, want 0", item.OutputTokens)
+	}
+}
+
+func TestPrettyToolName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"Bash", "Bash"},
+		{"Read", "Read"},
+		{"Skill", "Skill"},
+		{"mcp__plugin_context7_context7__query-docs", "mcp:query-docs"},
+		{"mcp__context7__resolve", "mcp:resolve"},
+		{"mcp__claude_ai_Gmail__authenticate", "mcp:authenticate"},
+		{"mcp__weird", "mcp__weird"}, // no trailing __method — passthrough
+	}
+	for _, tt := range tests {
+		if got := PrettyToolName(tt.in); got != tt.want {
+			t.Errorf("PrettyToolName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseLine_MCPToolUse_PrettifiesName(t *testing.T) {
+	line := `{"type":"assistant","timestamp":"2025-01-01T12:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"mcp__plugin_context7_context7__query-docs","input":{"library":"react"}}]}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].ToolName != "mcp:query-docs" {
+		t.Errorf("ToolName = %q, want %q", items[0].ToolName, "mcp:query-docs")
+	}
+}
+
+func TestParseLine_CacheTokensInAssistantMessage(t *testing.T) {
+	// cache_creation_input_tokens and cache_read_input_tokens are often much
+	// larger than the naked input_tokens, so undercounting them misleads users.
+	line := `{"type":"assistant","timestamp":"2025-01-01T12:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":35656,"cache_read_input_tokens":1234}}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	item := items[0]
+	if item.CacheCreationTokens != 35656 {
+		t.Errorf("CacheCreationTokens = %d, want 35656", item.CacheCreationTokens)
+	}
+	if item.CacheReadTokens != 1234 {
+		t.Errorf("CacheReadTokens = %d, want 1234", item.CacheReadTokens)
+	}
+	// existing fields still correct
+	if item.InputTokens != 10 || item.OutputTokens != 5 {
+		t.Errorf("Input/Output = %d/%d, want 10/5", item.InputTokens, item.OutputTokens)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,38 +22,44 @@ const (
 
 // Model is the main TUI model
 type Model struct {
-	tree              *TreeView
-	stream            *StreamView
-	watcher           *watcher.Watcher
-	focus             Focus
-	showTree          bool
-	width             int
-	height            int
-	treeWidth         int
-	sessionID         string
-	skipHistory       bool
-	pollInterval      time.Duration
-	activeWindow      time.Duration
-	maxSessions       int
-	err               error
-	quitting          bool
-	totalInputTokens  int64
-	totalOutputTokens int64
+	tree               *TreeView
+	stream             *StreamView
+	watcher            *watcher.Watcher
+	focus              Focus
+	showTree           bool
+	width              int
+	height             int
+	treeWidth          int
+	sessionID          string
+	skipHistory        bool
+	pollInterval       time.Duration
+	activeWindow       time.Duration
+	maxSessions        int
+	collapseAfter      time.Duration // 0 = disabled
+	err                error
+	quitting           bool
+	totalInputTokens   int64
+	totalOutputTokens  int64
+	totalCacheCreation int64
+	totalCacheRead     int64
 }
 
-// NewModel creates a new TUI model
-func NewModel(sessionID string, skipHistory bool, pollInterval time.Duration, activeWindow time.Duration, maxSessions int) *Model {
+// NewModel creates a new TUI model. If collapseAfter > 0, sessions inactive
+// for that duration will auto-collapse in the tree (and be hidden from the
+// stream). See tree.Toggle / Solo for the interactive counterpart.
+func NewModel(sessionID string, skipHistory bool, pollInterval time.Duration, activeWindow time.Duration, maxSessions int, collapseAfter time.Duration) *Model {
 	return &Model{
-		tree:         NewTreeView(),
-		stream:       NewStreamView(),
-		focus:        FocusStream,
-		showTree:     true,
-		treeWidth:    25,
-		sessionID:    sessionID,
-		skipHistory:  skipHistory,
-		pollInterval: pollInterval,
-		activeWindow: activeWindow,
-		maxSessions:  maxSessions,
+		tree:          NewTreeView(),
+		stream:        NewStreamView(),
+		focus:         FocusStream,
+		showTree:      true,
+		treeWidth:     25,
+		sessionID:     sessionID,
+		skipHistory:   skipHistory,
+		pollInterval:  pollInterval,
+		activeWindow:  activeWindow,
+		maxSessions:   maxSessions,
+		collapseAfter: collapseAfter,
 	}
 }
 
@@ -133,12 +139,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case streamItemMsg:
 		item := parser.StreamItem(msg)
+		// Session-title items update the tree label, not the stream.
+		if item.Type == parser.TypeSessionTitle {
+			m.tree.SetSessionTitle(item.SessionID, item.Content)
+			break
+		}
 		// Accumulate token usage (includes history — shows total session cost)
 		if item.InputTokens > 0 {
 			m.totalInputTokens += item.InputTokens
 		}
 		if item.OutputTokens > 0 {
 			m.totalOutputTokens += item.OutputTokens
+		}
+		if item.CacheCreationTokens > 0 {
+			m.totalCacheCreation += item.CacheCreationTokens
+		}
+		if item.CacheReadTokens > 0 {
+			m.totalCacheRead += item.CacheReadTokens
 		}
 		m.stream.AddItem(item)
 		m.stream.SetEnabledFilters(m.tree.GetEnabledFilters())
@@ -280,9 +297,52 @@ func (m *Model) updateActivityStatus() {
 	if m.watcher == nil {
 		return
 	}
-	// Check activity within last 30 seconds
-	for _, info := range m.watcher.GetActivityInfo(30 * time.Second) {
+	// Check activity within last 30 seconds. Gather infos once so the collapse
+	// policy sees the same snapshot.
+	infos := m.watcher.GetActivityInfo(30 * time.Second)
+	for _, info := range infos {
 		m.tree.UpdateActivity(info.SessionID, info.AgentID, info.IsActive)
+	}
+	if m.collapseAfter > 0 {
+		m.applyCollapsePolicy(infos)
+	}
+}
+
+// applyCollapsePolicy auto-collapses sessions whose newest-modified file is
+// older than collapseAfter. A session wakes up (LastModified is recent) →
+// any user-set Pin is cleared so the next sleep cycle re-auto-collapses.
+// This is the "pin resets on wake" semantic discussed in issue #5 Option D.
+func (m *Model) applyCollapsePolicy(infos []watcher.ActivityInfo) {
+	// Find newest LastModified across main + all agents per session.
+	latest := map[string]time.Time{}
+	for _, info := range infos {
+		if t, ok := latest[info.SessionID]; !ok || info.LastModified.After(t) {
+			latest[info.SessionID] = info.LastModified
+		}
+	}
+
+	now := time.Now()
+	for _, node := range m.tree.Root.Children {
+		if node.Type != NodeTypeSession {
+			continue
+		}
+		lastMod, ok := latest[node.ID]
+		if !ok {
+			continue
+		}
+
+		sessionActive := now.Sub(lastMod) < 30*time.Second
+		if sessionActive {
+			// Woke up: clear any prior pin so the next sleep cycle auto-collapses.
+			if node.Pinned {
+				m.tree.SetPinned(node.ID, false)
+			}
+			continue
+		}
+
+		if now.Sub(lastMod) >= m.collapseAfter && !node.Collapsed && !node.Pinned {
+			m.tree.SetCollapsed(node.ID, true)
+		}
 	}
 }
 
@@ -460,12 +520,18 @@ func (m *Model) renderHeader() string {
 		}
 	}
 
-	// Token usage display
+	// Token usage display (in / out / cache write+read)
 	tokenInfo := ""
-	if m.totalInputTokens > 0 || m.totalOutputTokens > 0 {
+	if m.totalInputTokens > 0 || m.totalOutputTokens > 0 ||
+		m.totalCacheCreation > 0 || m.totalCacheRead > 0 {
 		tokenInfo = fmt.Sprintf("│ %s in / %s out",
 			formatTokenCount(m.totalInputTokens),
 			formatTokenCount(m.totalOutputTokens))
+		if m.totalCacheCreation > 0 || m.totalCacheRead > 0 {
+			tokenInfo += fmt.Sprintf(" / %s+%s cache",
+				formatTokenCount(m.totalCacheCreation),
+				formatTokenCount(m.totalCacheRead))
+		}
 	}
 
 	// Build header - use plain text and apply headerStyle uniformly (like Rust version)

--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -223,6 +223,15 @@ func (s *StreamView) isItemEnabled(item parser.StreamItem) bool {
 }
 
 func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
+	// Turn markers are a standalone single-line divider — no agent header,
+	// no trailing separator. Return early so the universal separator tail
+	// below doesn't double up.
+	if item.Type == parser.TypeTurnMarker {
+		dur := formatDuration(item.DurationMs)
+		text := fmt.Sprintf("── turn ended %s ──", dur)
+		return mutedStyle.Render(text)
+	}
+
 	var b strings.Builder
 
 	// Agent name styling

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -38,6 +38,13 @@ type TreeNode struct {
 	ParentAgentID string // which agent spawned this task (empty = main)
 	OutputPath    string // path to tool-results file
 	IsComplete    bool   // whether the task has finished
+
+	// Session-only collapse state (used by -c / auto-collapse feature).
+	// Collapsed: children are hidden from tree navigation and stream filtering.
+	// Pinned: user manually expanded this session; suppress auto-collapse until
+	// the session wakes up again.
+	Collapsed bool
+	Pinned    bool
 }
 
 // TreeView manages the tree of sessions and agents
@@ -256,6 +263,11 @@ func (t *TreeView) rebuildNodeList() {
 
 func (t *TreeView) flattenNode(node *TreeNode, depth int) {
 	t.nodes = append(t.nodes, node)
+	// Collapsed sessions hide their children from navigation AND from the
+	// stream's enabled-filter set (GetEnabledFilters walks t.nodes).
+	if node.Type == NodeTypeSession && node.Collapsed {
+		return
+	}
 	for _, child := range node.Children {
 		t.flattenNode(child, depth+1)
 	}
@@ -275,23 +287,36 @@ func (t *TreeView) MoveDown() {
 	}
 }
 
-// Toggle toggles the enabled state of current node
+// Toggle toggles the current node's visibility.
+//
+// On a session node, space collapses/expands (hides children in the tree and
+// filters them from the stream). Manually expanding pins the session so
+// auto-collapse won't re-collapse it until the session wakes again.
+//
+// On Main/Agent/BackgroundTask nodes, space toggles the node's enabled state
+// (shows/hides that specific agent's output).
 func (t *TreeView) Toggle() {
-	if t.cursor >= 0 && t.cursor < len(t.nodes) {
-		node := t.nodes[t.cursor]
-		node.Enabled = !node.Enabled
-
-		// If toggling a session, toggle all children too
-		if node.Type == NodeTypeSession {
-			for _, child := range node.Children {
-				child.Enabled = node.Enabled
-			}
-		}
+	if t.cursor < 0 || t.cursor >= len(t.nodes) {
+		return
 	}
+	node := t.nodes[t.cursor]
+	if node.Type == NodeTypeSession {
+		node.Collapsed = !node.Collapsed
+		if !node.Collapsed {
+			node.Pinned = true
+		}
+		t.rebuildNodeList()
+		return
+	}
+	node.Enabled = !node.Enabled
 }
 
 // Solo isolates the selected node: disables all others, enables only this one.
 // If already soloed, re-enables all.
+//
+// If the target is a collapsed session, Solo force-expands it first (and
+// pins) — the whole point of soloing is to see that session's output, which
+// means its children must be visible in the tree and routed to the stream.
 func (t *TreeView) Solo() {
 	if t.cursor < 0 || t.cursor >= len(t.nodes) {
 		return
@@ -305,6 +330,14 @@ func (t *TreeView) Solo() {
 		// Disable all sessions and their children
 		for _, session := range t.Root.Children {
 			setAllEnabled(session, false)
+		}
+
+		// If soloing onto a collapsed session, expand it first so its
+		// children can be enabled and shown in the stream.
+		if selected.Type == NodeTypeSession && selected.Collapsed {
+			selected.Collapsed = false
+			selected.Pinned = true
+			defer t.rebuildNodeList()
 		}
 
 		// Enable the selected node and the path to it
@@ -364,6 +397,82 @@ func (t *TreeView) GetSelectedSession() string {
 		return node.SessionID
 	}
 	return ""
+}
+
+// SetCollapsed updates a session's collapse state. When collapsing, if the
+// cursor was pointing at a now-hidden child, it jumps up to the session row
+// so the user doesn't lose their position entirely. Setting collapsed=false
+// does NOT set Pinned — the caller decides (auto-wake vs user Toggle).
+func (t *TreeView) SetCollapsed(sessionID string, collapsed bool) {
+	for _, session := range t.Root.Children {
+		if session.Type != NodeTypeSession || session.ID != sessionID {
+			continue
+		}
+		if session.Collapsed == collapsed {
+			return
+		}
+		cursorNode := t.GetSelectedNode()
+		session.Collapsed = collapsed
+		t.rebuildNodeList()
+		// If the cursor was inside the subtree that just got hidden, move it
+		// up to the session row. Otherwise leave it alone — rebuildNodeList
+		// already clamps it to a valid range.
+		if collapsed && cursorNode != nil && cursorNode != session {
+			if t.nodeInSubtree(cursorNode, session) {
+				for i, n := range t.nodes {
+					if n == session {
+						t.cursor = i
+						break
+					}
+				}
+			}
+		}
+		return
+	}
+}
+
+// SetPinned sets the user-pinned flag on a session. Pinned sessions are
+// exempted from auto-collapse until they next wake up.
+func (t *TreeView) SetPinned(sessionID string, pinned bool) {
+	for _, session := range t.Root.Children {
+		if session.Type == NodeTypeSession && session.ID == sessionID {
+			session.Pinned = pinned
+			return
+		}
+	}
+}
+
+// nodeInSubtree returns true if needle appears anywhere in root's subtree.
+func (t *TreeView) nodeInSubtree(needle, root *TreeNode) bool {
+	if root == needle {
+		return true
+	}
+	for _, c := range root.Children {
+		if t.nodeInSubtree(needle, c) {
+			return true
+		}
+	}
+	return false
+}
+
+// SetSessionTitle updates the display name of a session node. Used when the
+// JSONL stream reports an agent-name or custom-title for the session, giving
+// users a human-readable label instead of the project path. Length is capped
+// so narrow tree panes don't overflow; the raw project name (25 char cap) was
+// the prior default, so we keep the same ceiling here.
+func (t *TreeView) SetSessionTitle(sessionID, title string) {
+	if title == "" {
+		return
+	}
+	for _, child := range t.Root.Children {
+		if child.Type == NodeTypeSession && child.ID == sessionID {
+			if len(title) > 25 {
+				title = title[:25]
+			}
+			child.Name = title
+			return
+		}
+	}
 }
 
 // RemoveSession removes a session and all its children from the tree
@@ -528,10 +637,14 @@ func (t *TreeView) View() string {
 		icon := ""
 		switch node.Type {
 		case NodeTypeSession:
+			arrow := "▾"
+			if node.Collapsed {
+				arrow = "▸"
+			}
 			if node.IsActive {
-				icon = "📁 "
+				icon = "📁" + arrow + " "
 			} else {
-				icon = "📂 "
+				icon = "📂" + arrow + " "
 			}
 		case NodeTypeMain:
 			if node.IsActive {
@@ -555,6 +668,19 @@ func (t *TreeView) View() string {
 
 		// Build line with name (muted if inactive)
 		name := node.Name
+		// Collapsed sessions show a hidden-agent count so users don't lose
+		// the signal that subagents exist underneath the collapsed node.
+		if node.Type == NodeTypeSession && node.Collapsed {
+			agents := 0
+			for _, c := range node.Children {
+				if c.Type == NodeTypeAgent {
+					agents++
+				}
+			}
+			if agents > 0 {
+				name = fmt.Sprintf("%s (+%d)", name, agents)
+			}
+		}
 		if !node.IsActive && node.Type != NodeTypeSession {
 			name = mutedStyle.Render(node.Name)
 		}

--- a/internal/tui/tree_test.go
+++ b/internal/tui/tree_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -120,31 +121,46 @@ func TestTreeView_AddBackgroundTaskUnderAgent(t *testing.T) {
 }
 
 func TestTreeView_Toggle(t *testing.T) {
+	// On a session node, space now collapses/expands (not enable/disable).
+	// On non-session nodes it still toggles the Enabled flag.
 	tv := NewTreeView()
 	tv.AddSession("sess1", "project")
+	tv.AddAgent("sess1", "agent1", "")
 
-	// Cursor is at session node (index 0)
-	tv.cursor = 0
+	tv.cursor = 0 // session
 	session := tv.Root.Children[0]
 
-	if !session.Enabled {
-		t.Error("session should be enabled by default")
+	if session.Collapsed {
+		t.Error("session should not be collapsed by default")
 	}
-
 	tv.Toggle()
-	if session.Enabled {
-		t.Error("session should be disabled after toggle")
+	if !session.Collapsed {
+		t.Error("session should be collapsed after first toggle")
 	}
-	// Children should also be disabled
+	// Children remain Enabled — collapse hides them in the tree/stream, but
+	// doesn't alter their per-node enable state.
 	for _, child := range session.Children {
-		if child.Enabled {
-			t.Error("child should be disabled when session is toggled off")
+		if !child.Enabled {
+			t.Error("children Enabled flag should be untouched by session collapse")
 		}
 	}
 
 	tv.Toggle()
-	if !session.Enabled {
-		t.Error("session should be re-enabled after second toggle")
+	if session.Collapsed {
+		t.Error("session should be expanded after second toggle")
+	}
+	if !session.Pinned {
+		t.Error("manual expand should pin the session")
+	}
+
+	// Non-session Toggle still flips Enabled.
+	// Cursor is back at 0 (session); move to Main (index 1) after rebuild.
+	tv.cursor = 1
+	main := tv.nodes[1]
+	wasEnabled := main.Enabled
+	tv.Toggle()
+	if main.Enabled == wasEnabled {
+		t.Error("Toggle on Main node should flip Enabled")
 	}
 }
 
@@ -339,6 +355,79 @@ func TestTreeView_ViewEmpty(t *testing.T) {
 	view := tv.View()
 	if view == "" {
 		t.Error("empty tree should still render something")
+	}
+}
+
+func TestTreeView_CollapseHidesChildrenFromFlatten(t *testing.T) {
+	tv := NewTreeView()
+	tv.AddSession("sess1", "project")
+	tv.AddAgent("sess1", "agent1", "")
+	// Before collapse: 3 nodes (session, main, agent)
+	if len(tv.nodes) != 3 {
+		t.Fatalf("pre-collapse: expected 3 nodes, got %d", len(tv.nodes))
+	}
+
+	tv.SetCollapsed("sess1", true)
+	// After collapse: only the session node remains in flattened list
+	if len(tv.nodes) != 1 {
+		t.Errorf("post-collapse: expected 1 node, got %d", len(tv.nodes))
+	}
+	if tv.nodes[0].Type != NodeTypeSession {
+		t.Error("post-collapse: only node should be the session")
+	}
+
+	// Collapsed session's children should also be absent from enabled filters.
+	if len(tv.GetEnabledFilters()) != 0 {
+		t.Error("collapsed session children should not appear in enabled filters")
+	}
+}
+
+func TestTreeView_CollapsedSessionShowsAgentCount(t *testing.T) {
+	tv := NewTreeView()
+	tv.AddSession("sess1", "project")
+	tv.AddAgent("sess1", "agent1", "")
+	tv.AddAgent("sess1", "agent2", "")
+	tv.SetCollapsed("sess1", true)
+	tv.SetSize(40, 10)
+
+	view := tv.View()
+	if !strings.Contains(view, "(+2)") {
+		t.Errorf("collapsed session view should show (+2) agent count, got:\n%s", view)
+	}
+}
+
+func TestTreeView_SetCollapsedMovesCursorUpFromHiddenChild(t *testing.T) {
+	tv := NewTreeView()
+	tv.AddSession("sess1", "project")
+	tv.AddAgent("sess1", "agent1", "")
+	tv.cursor = 2 // agent row
+
+	tv.SetCollapsed("sess1", true)
+	// Cursor should have moved from the now-hidden agent to the session row.
+	if tv.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 (session row)", tv.cursor)
+	}
+}
+
+func TestTreeView_SoloForceExpandsCollapsedSession(t *testing.T) {
+	// Needs ≥2 sessions so Solo actually enters solo mode (a lone session is
+	// trivially "already soloed" and Solo is a no-op).
+	tv := NewTreeView()
+	tv.AddSession("sess1", "project1")
+	tv.AddAgent("sess1", "agent1", "")
+	tv.AddSession("sess2", "project2")
+	tv.SetCollapsed("sess1", true)
+	// Cursor at sess1 (collapsed) — tree.nodes is [sess1, sess2, sess2-main]
+	tv.cursor = 0
+
+	tv.Solo()
+
+	session := tv.Root.Children[0]
+	if session.Collapsed {
+		t.Error("Solo on collapsed session should force-expand it")
+	}
+	if !session.Pinned {
+		t.Error("Solo on collapsed session should pin it")
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -422,9 +422,10 @@ func (w *Watcher) IsAutoDiscoveryEnabled() bool {
 
 // ActivityInfo contains activity status for a session/agent
 type ActivityInfo struct {
-	SessionID string
-	AgentID   string // empty for main
-	IsActive  bool
+	SessionID    string
+	AgentID      string // empty for main
+	IsActive     bool
+	LastModified time.Time // file mod time — used to drive auto-collapse policy
 }
 
 // GetActivityInfo returns activity status for all watched sessions and agents
@@ -440,9 +441,10 @@ func (w *Watcher) GetActivityInfo(activeWithin time.Duration) []ActivityInfo {
 		// Check main file
 		if fi, err := os.Stat(session.MainFile); err == nil {
 			info = append(info, ActivityInfo{
-				SessionID: session.ID,
-				AgentID:   "",
-				IsActive:  now.Sub(fi.ModTime()) < activeWithin,
+				SessionID:    session.ID,
+				AgentID:      "",
+				IsActive:     now.Sub(fi.ModTime()) < activeWithin,
+				LastModified: fi.ModTime(),
 			})
 		}
 
@@ -451,9 +453,10 @@ func (w *Watcher) GetActivityInfo(activeWithin time.Duration) []ActivityInfo {
 		for agentID, path := range session.Subagents {
 			if fi, err := os.Stat(path); err == nil {
 				info = append(info, ActivityInfo{
-					SessionID: session.ID,
-					AgentID:   agentID,
-					IsActive:  now.Sub(fi.ModTime()) < activeWithin,
+					SessionID:    session.ID,
+					AgentID:      agentID,
+					IsActive:     now.Sub(fi.ModTime()) < activeWithin,
+					LastModified: fi.ModTime(),
 				})
 			}
 		}
@@ -684,13 +687,13 @@ func formatToolName(toolName string, line string) string {
 		}
 	}
 
-	// For Task, try to get description
-	if toolName == "Task" {
+	// Task (legacy) and Agent (current name) both carry a "description" field
+	if toolName == "Task" || toolName == "Agent" {
 		if desc := extractField(line, "description"); desc != "" {
 			if len(desc) > 30 {
 				desc = desc[:30] + "..."
 			}
-			return "Task: " + desc
+			return toolName + ": " + desc
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	version = "0.4.7"
+	version = "0.5.0"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 	pollMs := flag.Int("p", 500, "Poll interval in milliseconds (min 100)")
 	activeWindowStr := flag.String("w", "5m", "Active window duration (e.g. 30s, 2m, 5m)")
 	maxSessions := flag.Int("m", 0, "Max sessions to show in tree (0=unlimited)")
+	collapseAfterStr := flag.String("c", "0", "Auto-collapse sessions inactive ≥ this duration (0=disabled, e.g. 2m)")
 	showVersion := flag.Bool("v", false, "Show version")
 	showHelp := flag.Bool("h", false, "Show help")
 
@@ -56,6 +57,16 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Invalid active window duration %q: %v\n", *activeWindowStr, err)
 		os.Exit(1)
+	}
+
+	// Parse collapse-after duration (0 = disabled)
+	var collapseAfter time.Duration
+	if *collapseAfterStr != "0" && *collapseAfterStr != "" {
+		collapseAfter, err = time.ParseDuration(*collapseAfterStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Invalid collapse duration %q: %v\n", *collapseAfterStr, err)
+			os.Exit(1)
+		}
 	}
 
 	if *listActive {
@@ -103,7 +114,7 @@ func main() {
 	}
 
 	// Run TUI
-	model := tui.NewModel(*sessionID, *skipHistory, pollInterval, activeWindow, *maxSessions)
+	model := tui.NewModel(*sessionID, *skipHistory, pollInterval, activeWindow, *maxSessions, collapseAfter)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	if _, err := p.Run(); err != nil {
@@ -139,6 +150,7 @@ OPTIONS:
     -p <ms>     Poll interval in ms, fallback mode only (default 500, min 100)
     -w <dur>    Active window duration (default 5m, e.g. 30s, 2m, 10m)
     -m <N>      Max sessions to show in tree (default 0=unlimited)
+    -c <dur>    Auto-collapse sessions inactive ≥ dur (0=disabled, e.g. 2m, 30s)
     -v          Show version
     -h          Show this help
 
@@ -155,7 +167,7 @@ KEYBINDINGS:
     x/d         Remove selected session (in tree)
     tab         Switch focus between tree and stream
     j/k         Navigate (tree) or scroll (stream)
-    space       Toggle agent visibility (in tree)
+    space       On agent: toggle visibility · On session: collapse/expand (pins on manual expand)
     g/G         Go to top/bottom of stream
     q           Quit
 

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -348,20 +348,36 @@ func TestFilters(t *testing.T) {
 }
 
 func TestTreeInteract(t *testing.T) {
+	// Space on a session node collapses (▾ → ▸). Space on a Main/Agent node
+	// flips its Enabled checkbox (☑ → ☐). Verify both.
 	s := espStart(t, 120, 40)
 	defer s.stop()
 
-	s.key("\t") // focus tree
-	time.Sleep(200 * time.Millisecond)
+	s.key("\t") // focus tree; cursor starts at session row
 
+	// 1) Space on session → collapse, arrow becomes ▸.
 	s.use()
-	exec.Command("tui-use", "type", " ").Run() // uncheck
+	exec.Command("tui-use", "type", " ").Run()
 	time.Sleep(400 * time.Millisecond)
-
 	screen := s.snap()
-	has(t, screen, "☐", "unchecked")
+	has(t, screen, "▸", "collapsed arrow")
+
+	// Space again → expand (pins), arrow back to ▾.
+	s.use()
+	exec.Command("tui-use", "type", " ").Run()
+	time.Sleep(400 * time.Millisecond)
+	screen = s.snap()
+	has(t, screen, "▾", "expanded arrow")
+
+	// 2) j to Main, then space → checkbox ☑ → ☐.
+	s.key("j")
+	s.use()
+	exec.Command("tui-use", "type", " ").Run()
+	time.Sleep(400 * time.Millisecond)
+	screen = s.snap()
+	has(t, screen, "☐", "main unchecked")
 
 	s.use()
-	exec.Command("tui-use", "type", " ").Run() // recheck
+	exec.Command("tui-use", "type", " ").Run()
 	time.Sleep(400 * time.Millisecond)
 }


### PR DESCRIPTION
## Summary

Claude Code's JSONL format has picked up new message types and tools since claude-esp was written. This PR brings parsing, header display, and tree rendering up to date, and lands issue #5 Option D (auto-collapse sleeping sessions).

Five beads issues, one commit:

### `claude-esp-7wb` · Tool formatters
New pretty-printers for common tool_use inputs that previously fell through to raw JSON:
- `Agent`/`Task` (description), `Skill`, `ToolSearch`, `ScheduleWakeup`, `TaskCreate`, `TaskUpdate`, `TaskStop`, `EnterPlanMode`, `ExitPlanMode`, `CronCreate`
- MCP tools shortened from `mcp__plugin_context7_context7__query-docs` → `mcp:query-docs`
- Fixes a silent regression: the `Task` → `Agent` tool rename landed upstream but our formatter and watcher still matched on the old name.

### `claude-esp-0pn` · Cache tokens
`UsageInfo` now reads `cache_creation_input_tokens` and `cache_read_input_tokens`. Header shows all four on one line: `5.2k in / 1.8k out / 35k+3k cache`. With prompt caching on by default, cache tokens are often the majority of real usage — previous totals significantly undercounted.

### `claude-esp-0jl` · New JSONL line types
`system.turn_duration` lines now surface as a dim divider (`── turn ended 41.8s ──`) so users see turn boundaries instead of silent gaps. Other new metadata types (`file-history-snapshot`, `queue-operation`, etc.) remain silently ignored.

### `claude-esp-ejf` · Session titles
`agent-name` and `custom-title` line types now update the session label in the tree. Replaces the generic project-path fallback with Claude's human-readable session name (e.g. `auto-collapse-sleeping-sessions`).

### `claude-esp-ml3` · Auto-collapse (issue #5 Option D)
- New `-c <dur>` flag (default disabled)
- Sessions idle ≥ dur auto-collapse in the tree
- Arrow indicator: `📁▾` (expanded) vs `📂▸` (collapsed); collapsed sessions show `(+N)` agent count so no signal is lost
- `space` on session toggles collapse; manual expansion **pins** the session until it wakes up again
- `s` (solo) force-expands a collapsed target
- Collapsed children are hidden from both the tree and the stream filter

## Test plan
- [x] `go test ./...` — all unit tests pass (new coverage for every formatter, cache tokens, turn marker, session title, collapse/flatten, solo-force-expand, agent count rendering)
- [x] `go test -tags=tui ./tests/` — all 7 tui-use integration tests pass (`TestTreeInteract` updated to match new space-on-session semantic)
- [x] `./claude-esp -c 2m` — manual smoke test: flag parses, help text documents it
- [ ] Manual: observe real session with `-c 30s` across an idle transition to verify pin-on-wake behavior

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)