### PR TITLE
Surface new Claude Code JSONL line types in stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ Thumbs.db
 
 # Claude artifacts
 AGENTS.md
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ When using Claude Code interactively, tool outputs and thinking are collapsed by
 - **Hierarchical tree view** - Sessions with nested Main/Agent nodes
 - **Real-time streaming** - See thinking, tool calls, and outputs as they happen
 - **Subagent tracking** - Automatically discovers and displays subagent activity
+- **Session events** - Compaction boundaries, hook output, post-edit LSP diagnostics, and PR-link events surfaced inline
 - **Agent type labels** - Shows agent types (Explore, code-reviewer, etc.) from `.meta.json`
 - **Token usage tracking** - Cumulative input/output token counts in the header bar
 - **Tool execution duration** - Shows how long each tool call took
@@ -70,6 +71,7 @@ claude-esp
 | `-w <dur>` | Active window duration (default `5m`, e.g. `30s`, `2m`) |
 | `-m <N>`   | Max sessions to show in tree (default 0 = unlimited) |
 | `-c <dur>` | Auto-collapse sessions inactive ≥ dur (default 0 = disabled, e.g. `2m`) |
+| `-D`       | Debug: surface raw `type:subtype` for every JSONL line type the parser would otherwise drop |
 | `-v`       | Show version                                  |
 | `-h`       | Show help                                     |
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -11,16 +11,39 @@ import (
 type StreamItemType string
 
 const (
-	TypeThinking     StreamItemType = "thinking"
-	TypeToolInput    StreamItemType = "tool_input"
-	TypeToolOutput   StreamItemType = "tool_output"
-	TypeText         StreamItemType = "text"
-	TypeTurnMarker   StreamItemType = "turn_marker"   // turn boundary + duration (system.turn_duration)
-	TypeSessionTitle StreamItemType = "session_title" // session label update (agent-name / custom-title)
+	TypeThinking      StreamItemType = "thinking"
+	TypeToolInput     StreamItemType = "tool_input"
+	TypeToolOutput    StreamItemType = "tool_output"
+	TypeText          StreamItemType = "text"
+	TypeTurnMarker    StreamItemType = "turn_marker"    // turn boundary + duration (system.turn_duration)
+	TypeCompactMarker StreamItemType = "compact_marker" // conversation compaction boundary (system.compact_boundary)
+	TypeHookOutput    StreamItemType = "hook_output"    // hook execution result (attachment.hook_success)
+	TypeDiagnostics   StreamItemType = "diagnostics"    // post-edit LSP diagnostics (attachment.diagnostics)
+	TypePRLink        StreamItemType = "pr_link"        // PR creation event (type=pr-link)
+	TypeDebug         StreamItemType = "debug"          // raw line type/subtype (only emitted when DebugAll is on)
+	TypeSessionTitle  StreamItemType = "session_title"  // session label update (agent-name / custom-title)
 
 	// AgentIDDisplayLength is how many chars of agent ID to show in display name
 	AgentIDDisplayLength = 7
+
+	// debugPreviewLen caps the raw-line preview shown in TypeDebug items.
+	debugPreviewLen = 240
 )
+
+// DebugAll, when true, makes ParseLine emit a TypeDebug stream item for every
+// line whose type (or attachment subtype) is otherwise dropped by the parser.
+// Set this once at startup based on a CLI flag; safe to leave at false in
+// production. Reads/writes are not synchronized — flip before parsing starts.
+var DebugAll bool
+
+// agentDisplayName returns "Main" for the top-level session or "Agent-<id>"
+// (truncated to AgentIDDisplayLength) for subagents.
+func agentDisplayName(agentID string) string {
+	if agentID == "" {
+		return "Main"
+	}
+	return fmt.Sprintf("Agent-%s", agentID[:min(AgentIDDisplayLength, len(agentID))])
+}
 
 // StreamItem represents a single item in the output stream
 type StreamItem struct {
@@ -54,6 +77,51 @@ type RawMessage struct {
 	// and type="custom-title" lines respectively.
 	AgentTitle  string `json:"agentName,omitempty"`
 	CustomTitle string `json:"customTitle,omitempty"`
+	// CompactMetadata carries trigger + preTokens on system.compact_boundary lines.
+	CompactMetadata *CompactMetadata `json:"compactMetadata,omitempty"`
+	// Attachment carries hook output / diagnostics / etc on type="attachment" lines.
+	Attachment *Attachment `json:"attachment,omitempty"`
+	// PR link fields (type=pr-link).
+	PRNumber     int    `json:"prNumber,omitempty"`
+	PRURL        string `json:"prUrl,omitempty"`
+	PRRepository string `json:"prRepository,omitempty"`
+}
+
+// CompactMetadata describes a conversation-compaction event.
+type CompactMetadata struct {
+	Trigger   string `json:"trigger"`
+	PreTokens int64  `json:"preTokens"`
+}
+
+// Attachment is the payload on type="attachment" lines. Subtype-dependent
+// fields are kept in one struct to avoid per-subtype unmarshalling.
+type Attachment struct {
+	Type      string `json:"type"`
+	HookName  string `json:"hookName,omitempty"`
+	HookEvent string `json:"hookEvent,omitempty"`
+	// Content is omitted because subtypes disagree on its shape
+	// (hook_success: string; task_reminder: array). Use Stdout for hooks.
+	Stdout     string `json:"stdout,omitempty"`
+	Stderr     string `json:"stderr,omitempty"`
+	Command    string `json:"command,omitempty"`
+	ExitCode   int    `json:"exitCode,omitempty"`
+	DurationMs int64  `json:"durationMs,omitempty"`
+	// Diagnostics fields (attachment.type=diagnostics)
+	Files []DiagnosticFile `json:"files,omitempty"`
+}
+
+// DiagnosticFile is one file's worth of LSP diagnostics.
+type DiagnosticFile struct {
+	URI         string       `json:"uri"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+// Diagnostic is a single LSP finding.
+type Diagnostic struct {
+	Message  string `json:"message"`
+	Severity string `json:"severity"`
+	Source   string `json:"source"`
+	Code     string `json:"code"`
 }
 
 // RawToolUseResult represents the toolUseResult field on user messages
@@ -148,13 +216,169 @@ func ParseLine(line string) ([]StreamItem, error) {
 		items = parseUserMessage(raw, timestamp)
 	case "system":
 		items = parseSystemMessage(raw, timestamp)
+		if DebugAll && len(items) == 0 {
+			items = []StreamItem{debugItem(raw, line, timestamp)}
+		}
 	case "agent-name":
 		items = parseSessionTitle(raw, timestamp, raw.AgentTitle)
 	case "custom-title":
 		items = parseSessionTitle(raw, timestamp, raw.CustomTitle)
+	case "attachment":
+		items = parseAttachment(raw, timestamp)
+		if DebugAll && len(items) == 0 {
+			items = []StreamItem{debugItem(raw, line, timestamp)}
+		}
+	case "pr-link":
+		items = parsePRLink(raw, timestamp)
+	default:
+		if DebugAll {
+			items = []StreamItem{debugItem(raw, line, timestamp)}
+		}
 	}
 
 	return items, nil
+}
+
+// debugItem builds a TypeDebug stream item describing a line that the parser
+// would otherwise drop. The label is "<type>" or "<type>:<subtype>" for system
+// lines, or "attachment.<subtype>" for attachments. Content is a truncated
+// raw-JSON preview to help diagnose new fields.
+func debugItem(raw RawMessage, line string, timestamp time.Time) StreamItem {
+	label := raw.Type
+	switch {
+	case raw.Type == "system" && raw.Subtype != "":
+		label = "system:" + raw.Subtype
+	case raw.Type == "attachment" && raw.Attachment != nil && raw.Attachment.Type != "":
+		label = "attachment." + raw.Attachment.Type
+	}
+	preview := line
+	if len(preview) > debugPreviewLen {
+		preview = preview[:debugPreviewLen] + "…"
+	}
+	agentName := agentDisplayName(raw.AgentID)
+	return StreamItem{
+		Type:      TypeDebug,
+		SessionID: raw.SessionID,
+		AgentID:   raw.AgentID,
+		AgentName: agentName,
+		Timestamp: timestamp,
+		ToolName:  label,
+		Content:   preview,
+	}
+}
+
+// parseAttachment dispatches on attachment.type. Surfaces hook_success and
+// diagnostics; every other subtype is intentionally dropped (the DebugAll
+// flag will surface the rest as TypeDebug items).
+func parseAttachment(raw RawMessage, timestamp time.Time) []StreamItem {
+	if raw.Attachment == nil {
+		return nil
+	}
+	agentName := agentDisplayName(raw.AgentID)
+
+	switch raw.Attachment.Type {
+	case "hook_success":
+		body := raw.Attachment.Stdout
+		return []StreamItem{{
+			Type:       TypeHookOutput,
+			SessionID:  raw.SessionID,
+			AgentID:    raw.AgentID,
+			AgentName:  agentName,
+			Timestamp:  timestamp,
+			ToolName:   raw.Attachment.HookName,
+			Content:    body,
+			DurationMs: raw.Attachment.DurationMs,
+		}}
+	case "diagnostics":
+		return diagnosticsItems(raw, timestamp, agentName)
+	}
+	return nil
+}
+
+// diagnosticsItems turns one diagnostics attachment (potentially multi-file)
+// into one StreamItem per file. Files with zero diagnostics are skipped.
+func diagnosticsItems(raw RawMessage, timestamp time.Time, agentName string) []StreamItem {
+	var items []StreamItem
+	for _, f := range raw.Attachment.Files {
+		if len(f.Diagnostics) == 0 {
+			continue
+		}
+		items = append(items, StreamItem{
+			Type:      TypeDiagnostics,
+			SessionID: raw.SessionID,
+			AgentID:   raw.AgentID,
+			AgentName: agentName,
+			Timestamp: timestamp,
+			ToolName:  diagnosticsHeader(f),
+			Content:   diagnosticsBody(f.Diagnostics),
+		})
+	}
+	return items
+}
+
+// diagnosticsHeader returns "<file> (2 errors, 5 hints)".
+func diagnosticsHeader(f DiagnosticFile) string {
+	counts := map[string]int{}
+	for _, d := range f.Diagnostics {
+		counts[strings.ToLower(d.Severity)]++
+	}
+	var parts []string
+	for _, sev := range []string{"error", "warning", "info", "hint"} {
+		if n := counts[sev]; n > 0 {
+			label := sev + "s"
+			if n == 1 {
+				label = sev
+			}
+			parts = append(parts, fmt.Sprintf("%d %s", n, label))
+		}
+	}
+	name := f.URI
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	if len(parts) == 0 {
+		return name
+	}
+	return fmt.Sprintf("%s (%s)", name, strings.Join(parts, ", "))
+}
+
+// diagnosticsBody renders each diagnostic as "[severity] message (source)".
+func diagnosticsBody(ds []Diagnostic) string {
+	lines := make([]string, 0, len(ds))
+	for _, d := range ds {
+		sev := d.Severity
+		if sev == "" {
+			sev = "?"
+		}
+		line := fmt.Sprintf("[%s] %s", sev, d.Message)
+		if d.Source != "" {
+			line += fmt.Sprintf(" (%s)", d.Source)
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// parsePRLink emits a TypePRLink marker for type="pr-link" events.
+func parsePRLink(raw RawMessage, timestamp time.Time) []StreamItem {
+	if raw.PRNumber == 0 && raw.PRURL == "" {
+		return nil
+	}
+	var content string
+	switch {
+	case raw.PRRepository != "" && raw.PRURL != "":
+		content = fmt.Sprintf("PR #%d %s → %s", raw.PRNumber, raw.PRRepository, raw.PRURL)
+	case raw.PRURL != "":
+		content = fmt.Sprintf("PR #%d → %s", raw.PRNumber, raw.PRURL)
+	default:
+		content = fmt.Sprintf("PR #%d", raw.PRNumber)
+	}
+	return []StreamItem{{
+		Type:      TypePRLink,
+		SessionID: raw.SessionID,
+		Timestamp: timestamp,
+		Content:   content,
+	}}
 }
 
 // parseSessionTitle emits a TypeSessionTitle item carrying a human-readable
@@ -172,24 +396,64 @@ func parseSessionTitle(raw RawMessage, timestamp time.Time, title string) []Stre
 	}}
 }
 
-// parseSystemMessage handles system-type JSONL lines. Currently surfaces only
-// subtype=turn_duration (emitted when a full assistant turn finishes) as a
-// subtle marker in the stream. Other subtypes are intentionally dropped.
+// parseSystemMessage handles system-type JSONL lines. Surfaces:
+//   - subtype=turn_duration → TypeTurnMarker (turn ended + duration)
+//   - subtype=compact_boundary → TypeCompactMarker (auto/manual compaction with preTokens)
+//
+// Other subtypes are intentionally dropped.
 func parseSystemMessage(raw RawMessage, timestamp time.Time) []StreamItem {
-	if raw.Subtype != "turn_duration" {
-		return nil
+	agentName := agentDisplayName(raw.AgentID)
+
+	switch raw.Subtype {
+	case "turn_duration":
+		return []StreamItem{{
+			Type:       TypeTurnMarker,
+			SessionID:  raw.SessionID,
+			AgentID:    raw.AgentID,
+			AgentName:  agentName,
+			Timestamp:  timestamp,
+			DurationMs: raw.DurationMs,
+		}}
+	case "compact_boundary":
+		content := formatCompactSummary(raw.CompactMetadata)
+		return []StreamItem{{
+			Type:      TypeCompactMarker,
+			SessionID: raw.SessionID,
+			AgentID:   raw.AgentID,
+			AgentName: agentName,
+			Timestamp: timestamp,
+			Content:   content,
+		}}
 	}
-	agentName := "Main"
-	if raw.AgentID != "" {
-		agentName = fmt.Sprintf("Agent-%s", raw.AgentID[:min(AgentIDDisplayLength, len(raw.AgentID))])
+	return nil
+}
+
+// formatCompactSummary renders compaction metadata into a short label like
+// "auto, 179k pre-tokens". Returns "" when no metadata is present.
+func formatCompactSummary(m *CompactMetadata) string {
+	if m == nil {
+		return ""
 	}
-	return []StreamItem{{
-		Type:       TypeTurnMarker,
-		AgentID:    raw.AgentID,
-		AgentName:  agentName,
-		Timestamp:  timestamp,
-		DurationMs: raw.DurationMs,
-	}}
+	var parts []string
+	if m.Trigger != "" {
+		parts = append(parts, m.Trigger)
+	}
+	if m.PreTokens > 0 {
+		parts = append(parts, fmt.Sprintf("%s pre-tokens", formatTokenCount(m.PreTokens)))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatTokenCount renders a token count as 1.2k / 179k / 2.3M.
+func formatTokenCount(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%dk", n/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
 }
 
 func parseAssistantMessage(raw RawMessage, timestamp time.Time) []StreamItem {
@@ -199,10 +463,7 @@ func parseAssistantMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 	}
 
 	var items []StreamItem
-	agentName := "Main"
-	if raw.AgentID != "" {
-		agentName = fmt.Sprintf("Agent-%s", raw.AgentID[:min(AgentIDDisplayLength, len(raw.AgentID))])
-	}
+	agentName := agentDisplayName(raw.AgentID)
 
 	for _, block := range msg.Content {
 		switch block.Type {
@@ -270,10 +531,7 @@ func parseUserMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 	}
 
 	var items []StreamItem
-	agentName := "Main"
-	if raw.AgentID != "" {
-		agentName = fmt.Sprintf("Agent-%s", raw.AgentID[:min(AgentIDDisplayLength, len(raw.AgentID))])
-	}
+	agentName := agentDisplayName(raw.AgentID)
 
 	for _, result := range results {
 		if result.Type == "tool_result" {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -325,6 +325,160 @@ func TestParseLine_TurnDuration(t *testing.T) {
 	}
 }
 
+func TestParseLine_CompactBoundary(t *testing.T) {
+	line := `{"type":"system","subtype":"compact_boundary","timestamp":"2025-01-01T12:00:00Z","sessionId":"abc","compactMetadata":{"trigger":"auto","preTokens":179698}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 compact marker, got %d", len(items))
+	}
+	if items[0].Type != TypeCompactMarker {
+		t.Errorf("type = %q, want %q", items[0].Type, TypeCompactMarker)
+	}
+	if items[0].Content != "auto, 179k pre-tokens" {
+		t.Errorf("content = %q, want %q", items[0].Content, "auto, 179k pre-tokens")
+	}
+	if items[0].SessionID != "abc" {
+		t.Errorf("sessionID = %q, want abc", items[0].SessionID)
+	}
+}
+
+func TestParseLine_CompactBoundary_NoMetadata(t *testing.T) {
+	line := `{"type":"system","subtype":"compact_boundary","timestamp":"2025-01-01T12:00:00Z","sessionId":"abc"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeCompactMarker {
+		t.Fatalf("expected 1 compact marker, got %+v", items)
+	}
+	if items[0].Content != "" {
+		t.Errorf("content = %q, want empty", items[0].Content)
+	}
+}
+
+func TestParseLine_HookSuccess(t *testing.T) {
+	line := `{"type":"attachment","timestamp":"2025-01-01T12:00:00Z","sessionId":"abc","attachment":{"type":"hook_success","hookName":"SessionStart:startup","hookEvent":"SessionStart","stdout":"hello\nworld","exitCode":0,"durationMs":116,"command":"bd prime"}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 hook item, got %d", len(items))
+	}
+	if items[0].Type != TypeHookOutput {
+		t.Errorf("type = %q, want %q", items[0].Type, TypeHookOutput)
+	}
+	if items[0].ToolName != "SessionStart:startup" {
+		t.Errorf("toolName = %q, want SessionStart:startup", items[0].ToolName)
+	}
+	if items[0].DurationMs != 116 {
+		t.Errorf("duration = %d, want 116", items[0].DurationMs)
+	}
+	if items[0].Content != "hello\nworld" {
+		t.Errorf("content = %q, want hello\\nworld", items[0].Content)
+	}
+}
+
+func TestParseLine_AttachmentUnknownSubtypeDropped(t *testing.T) {
+	line := `{"type":"attachment","timestamp":"2025-01-01T12:00:00Z","sessionId":"abc","attachment":{"type":"task_reminder","content":[],"itemCount":0}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items for unhandled subtype, got %d", len(items))
+	}
+}
+
+func TestParseLine_Diagnostics(t *testing.T) {
+	line := `{"type":"attachment","timestamp":"2025-01-01T12:00:00Z","sessionId":"abc","attachment":{"type":"diagnostics","files":[{"uri":"/path/to/foo.go","diagnostics":[{"message":"unused parameter","severity":"Info","source":"unusedparams"},{"message":"loop can be modernized","severity":"Hint","source":"rangeint"}]}]}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 diagnostics item, got %d", len(items))
+	}
+	if items[0].Type != TypeDiagnostics {
+		t.Errorf("type = %q, want %q", items[0].Type, TypeDiagnostics)
+	}
+	if items[0].ToolName != "foo.go (1 info, 1 hint)" {
+		t.Errorf("toolName = %q, want %q", items[0].ToolName, "foo.go (1 info, 1 hint)")
+	}
+	if !strings.Contains(items[0].Content, "[Info] unused parameter (unusedparams)") {
+		t.Errorf("content missing first diagnostic: %q", items[0].Content)
+	}
+}
+
+func TestParseLine_DebugAll(t *testing.T) {
+	prev := DebugAll
+	DebugAll = true
+	t.Cleanup(func() { DebugAll = prev })
+
+	tests := []struct {
+		name      string
+		line      string
+		wantLabel string
+	}{
+		{"unknown top-level", `{"type":"file-history-snapshot","sessionId":"s","timestamp":"2025-01-01T12:00:00Z"}`, "file-history-snapshot"},
+		{"system unknown subtype", `{"type":"system","subtype":"foo","sessionId":"s","timestamp":"2025-01-01T12:00:00Z"}`, "system:foo"},
+		{"attachment unhandled", `{"type":"attachment","sessionId":"s","timestamp":"2025-01-01T12:00:00Z","attachment":{"type":"task_reminder","content":[],"itemCount":0}}`, "attachment.task_reminder"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			items, err := ParseLine(tc.line)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(items) != 1 || items[0].Type != TypeDebug {
+				t.Fatalf("expected 1 debug item, got %+v", items)
+			}
+			if items[0].ToolName != tc.wantLabel {
+				t.Errorf("label = %q, want %q", items[0].ToolName, tc.wantLabel)
+			}
+		})
+	}
+}
+
+func TestParseLine_DebugAllSkipsHandledLines(t *testing.T) {
+	prev := DebugAll
+	DebugAll = true
+	t.Cleanup(func() { DebugAll = prev })
+
+	// pr-link is handled → should NOT also produce a debug item.
+	line := `{"type":"pr-link","sessionId":"s","prNumber":1,"prUrl":"http://x","prRepository":"a/b","timestamp":"2025-01-01T12:00:00Z"}`
+	items, _ := ParseLine(line)
+	if len(items) != 1 || items[0].Type != TypePRLink {
+		t.Fatalf("expected exactly 1 pr_link item, got %+v", items)
+	}
+}
+
+func TestParseLine_PRLink(t *testing.T) {
+	line := `{"type":"pr-link","sessionId":"abc","prNumber":13,"prUrl":"https://github.com/phiat/claude-esp/pull/13","prRepository":"phiat/claude-esp","timestamp":"2025-01-01T12:00:00Z"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypePRLink {
+		t.Fatalf("expected 1 pr_link item, got %+v", items)
+	}
+	want := "PR #13 phiat/claude-esp → https://github.com/phiat/claude-esp/pull/13"
+	if items[0].Content != want {
+		t.Errorf("content = %q, want %q", items[0].Content, want)
+	}
+}
+
+func TestParseLine_DiagnosticsEmptyFilesSkipped(t *testing.T) {
+	line := `{"type":"attachment","timestamp":"2025-01-01T12:00:00Z","sessionId":"abc","attachment":{"type":"diagnostics","files":[{"uri":"/x.go","diagnostics":[]}]}}`
+	items, _ := ParseLine(line)
+	if len(items) != 0 {
+		t.Fatalf("expected files with no diagnostics to be skipped, got %d items", len(items))
+	}
+}
+
 func TestFormatToolInput(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -231,6 +231,16 @@ func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
 		text := fmt.Sprintf("── turn ended %s ──", dur)
 		return mutedStyle.Render(text)
 	}
+	if item.Type == parser.TypeCompactMarker {
+		text := "── compacted ──"
+		if item.Content != "" {
+			text = fmt.Sprintf("── compacted (%s) ──", item.Content)
+		}
+		return mutedStyle.Render(text)
+	}
+	if item.Type == parser.TypePRLink {
+		return mutedStyle.Render(fmt.Sprintf("── %s ──", item.Content))
+	}
 
 	var b strings.Builder
 
@@ -287,6 +297,45 @@ func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
 		b.WriteString(fmt.Sprintf("%s%s%s\n", agentName, sep, header))
 		content := s.truncateContent(item.Content, width)
 		b.WriteString(content)
+
+	case parser.TypeHookOutput:
+		label := hookIcon + " Hook"
+		if item.ToolName != "" {
+			label += " " + item.ToolName
+		}
+		if item.DurationMs > 0 {
+			label += " " + formatDuration(item.DurationMs)
+		}
+		header := hookStyle.Render(label)
+		b.WriteString(fmt.Sprintf("%s%s%s\n", agentName, sep, header))
+		if item.Content != "" {
+			content := s.truncateContent(item.Content, width)
+			b.WriteString(hookContentStyle.Render(content))
+		}
+
+	case parser.TypeDiagnostics:
+		label := diagnosticsIcon + " Diagnostics"
+		if item.ToolName != "" {
+			label += " " + item.ToolName
+		}
+		header := diagnosticsStyle.Render(label)
+		b.WriteString(fmt.Sprintf("%s%s%s\n", agentName, sep, header))
+		if item.Content != "" {
+			content := s.truncateContent(item.Content, width)
+			b.WriteString(diagnosticsContentStyle.Render(content))
+		}
+
+	case parser.TypeDebug:
+		label := debugIcon + " Debug"
+		if item.ToolName != "" {
+			label += " " + item.ToolName
+		}
+		header := debugStyle.Render(label)
+		b.WriteString(fmt.Sprintf("%s%s%s\n", agentName, sep, header))
+		if item.Content != "" {
+			content := s.truncateContent(item.Content, width)
+			b.WriteString(debugContentStyle.Render(content))
+		}
 	}
 
 	// Add separator line

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -40,6 +40,30 @@ var (
 	textStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#F9FAFB"))
 
+	// Hook style - cyan (system-injected output, distinct from tool calls)
+	hookIcon  = "🪝"
+	hookStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#06B6D4")).
+			Bold(true)
+	hookContentStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#67E8F9"))
+
+	// Diagnostics style - red-ish (LSP findings after edits)
+	diagnosticsIcon  = "⚠"
+	diagnosticsStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#F87171")).
+				Bold(true)
+	diagnosticsContentStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#FCA5A5"))
+
+	// Debug style - dim grey/orange, used for -D flag
+	debugIcon  = "🔍"
+	debugStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#9CA3AF")).
+			Bold(true)
+	debugContentStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#9CA3AF"))
+
 	// Agent name styles
 	mainAgentStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#60A5FA")).

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/phiat/claude-esp/internal/parser"
 	"github.com/phiat/claude-esp/internal/tui"
 	"github.com/phiat/claude-esp/internal/watcher"
 )
@@ -37,10 +38,13 @@ func main() {
 	activeWindowStr := flag.String("w", "5m", "Active window duration (e.g. 30s, 2m, 5m)")
 	maxSessions := flag.Int("m", 0, "Max sessions to show in tree (0=unlimited)")
 	collapseAfterStr := flag.String("c", "0", "Auto-collapse sessions inactive ≥ this duration (0=disabled, e.g. 2m)")
+	debugAll := flag.Bool("D", false, "Debug: surface raw type:subtype for every JSONL line type the parser would otherwise drop")
 	showVersion := flag.Bool("v", false, "Show version")
 	showHelp := flag.Bool("h", false, "Show help")
 
 	flag.Parse()
+
+	parser.DebugAll = *debugAll
 
 	if *showHelp {
 		printHelp()
@@ -151,6 +155,7 @@ OPTIONS:
     -w <dur>    Active window duration (default 5m, e.g. 30s, 2m, 10m)
     -m <N>      Max sessions to show in tree (default 0=unlimited)
     -c <dur>    Auto-collapse sessions inactive ≥ dur (0=disabled, e.g. 2m, 30s)
+    -D          Debug: show raw type:subtype for every JSONL line we'd drop
     -v          Show version
     -h          Show this help
 


### PR DESCRIPTION
## Summary

Claude Code 2.1.x added several JSONL line types that the parser was silently dropping. This PR adds parser support and inline rendering for the high-signal ones, plus a debug flag to surface anything else.

**New events rendered inline:**
- `system.compact_boundary` → `── compacted (auto, 179k pre-tokens) ──`
- `attachment.hook_success` → 🪝 Hook header with name + duration + stdout
- `attachment.diagnostics` → ⚠ per-file LSP findings (severity-tagged: errors, warnings, info, hints)
- `pr-link` → `── PR #N repo → url ──` divider

**New `-D` flag:** surfaces the raw `type:subtype` for every JSONL line the parser would otherwise drop (`file-history-snapshot`, `last-prompt`, `permission-mode`, `queue-operation`, the remaining attachment subtypes, etc.). Useful for spotting future format drift.

**Drive-by:** extracted the repeated `agentName` derivation (5 call sites) into a small `agentDisplayName` helper.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes (added 8 new parser tests covering compact_boundary, hook_success, diagnostics, pr-link, debug-all-on, debug-skips-handled-lines, attachment-unknown-subtype-dropped, diagnostics-empty-files-skipped)
- [x] `gofmt -d` clean
- [x] Smoke-tested against a real session jsonl: parses 1 hook, 19 diagnostics, 36 pr_link, 11 turn_marker entries cleanly; with `-D` correctly surfaces task_reminder × 36, last-prompt × 60, permission-mode × 61, etc., without false positives on assistant/user messages
- [ ] Visual sanity-check in `claude-esp -D` against a live session