### PR TITLE
Drop ☑/☐ from header toggle bar

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -566,11 +566,14 @@ func formatTokenCount(n int64) string {
 }
 
 func (m *Model) renderToggle(name string, enabled bool, key string) string {
-	checkbox := "☐"
-	if enabled {
-		checkbox = "☑"
+	// Drop the ☑/☐ checkbox column — disabled toggles get a leading
+	// mid-dot marker, enabled toggles a leading space, so the bar's
+	// column widths stay aligned without the checkbox.
+	marker := " "
+	if !enabled {
+		marker = "·"
 	}
-	return fmt.Sprintf("%s %s[%s]", checkbox, name, key)
+	return fmt.Sprintf("%s%s[%s]", marker, name, key)
 }
 
 func (m *Model) renderWithTree() string {


### PR DESCRIPTION
## Summary

Follow-up to #17 — the tree row already lost its checkbox column, but the header toggle bar still carried ☑/☐ icons. Removes them for visual consistency.

- Disabled toggles render with a leading mid-dot (\`·Thinking[t]\`)
- Enabled toggles render with a leading space (\` Thinking[t]\`)
- Column widths stay aligned so the bar doesn't shift as toggles flip

Verified live with tui-use — disabled state shows a clear mid-dot marker; enabled state is clean.

## Test plan

- [ ] \`go test ./...\` passes
- [ ] Run \`claude-esp\`, press \`t\`/\`i\`/\`o\` etc., confirm the leading marker swaps between space and mid-dot
- [ ] Confirm the bar's overall layout doesn't shift width when toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)