### PR TITLE
Fix TUI panic on narrow terminal: negative strings.Repeat count

### DIFF
--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -176,6 +176,9 @@ func (s *StreamView) IsAutoScrollEnabled() bool {
 func (s *StreamView) updateContent() {
 	var b strings.Builder
 	contentWidth := s.width - 4 // account for borders and padding
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
 
 	for _, item := range s.items {
 		// Check session/agent filter
@@ -339,7 +342,11 @@ func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
 	}
 
 	// Add separator line
-	b.WriteString("\n" + separatorStyle.Render(strings.Repeat("─", min(width, 60))))
+	sepWidth := min(width, 60)
+	if sepWidth < 0 {
+		sepWidth = 0
+	}
+	b.WriteString("\n" + separatorStyle.Render(strings.Repeat("─", sepWidth)))
 
 	return b.String()
 }

--- a/internal/tui/stream_test.go
+++ b/internal/tui/stream_test.go
@@ -244,6 +244,37 @@ func TestTruncateContent_Emoji(t *testing.T) {
 	}
 }
 
+// TestStreamView_NarrowResizeDoesNotPanic guards against a regression where
+// SetSize stored a small/negative raw width in s.width while clamping only
+// the viewport, causing strings.Repeat in renderItem to panic with
+// "negative Repeat count" once an item was rendered.
+func TestStreamView_NarrowResizeDoesNotPanic(t *testing.T) {
+	s := NewStreamView()
+	s.SetSize(80, 24)
+	s.SetEnabledFilters([]EnabledFilter{{SessionID: "sess1", AgentID: ""}})
+	// Cover every render branch that uses width.
+	for _, typ := range []parser.StreamItemType{
+		parser.TypeThinking,
+		parser.TypeToolInput,
+		parser.TypeToolOutput,
+		parser.TypeText,
+		parser.TypeHookOutput,
+		parser.TypeDiagnostics,
+		parser.TypeDebug,
+	} {
+		s.AddItem(newTestItem(typ, "sess1", "", "content"))
+	}
+
+	// Each width here corresponds to a real callsite scenario where
+	// model.go passes m.width-m.treeWidth-5 (or similar) and the result
+	// underflows the inner content width.
+	for _, width := range []int{0, 1, 2, 3, 4, 5, -1, -10} {
+		// Should never panic, even with an unrenderably narrow width.
+		s.SetSize(width, 5)
+		_ = s.View()
+	}
+}
+
 func TestStreamView_ToggleStates(t *testing.T) {
 	s := NewStreamView()
 


### PR DESCRIPTION
## Summary

- Fixes a panic (`strings: negative Repeat count`) that crashed the TUI when the terminal was resized so that the stream pane's effective inner width dropped below 4 columns.
- Adds a regression test exercising every render branch with widths down to `-10`.

## Root cause

`StreamView.SetSize` clamped `innerWidth`/`innerHeight` for the viewport but stored the raw caller-provided width in `s.width`. With the tree visible, `model.go:456` calls `SetSize(m.width-m.treeWidth-5, ...)`, which can go negative on narrow terminals. `updateContent` then computed `contentWidth := s.width - 4` (more negative), passed it to `renderItem`, where `strings.Repeat(\"─\", min(width, 60))` panicked.

Trace from the user's crash:
```
strings.Repeat({0x5d92cb?, 0x400?}, 0x0?)  → panic
internal/tui.(*StreamView).renderItem  stream.go:342
internal/tui.(*StreamView).updateContent stream.go:206
internal/tui.(*StreamView).SetSize       stream.go:82
internal/tui.(*Model).updateLayout       model.go:456
```

## Fix

- Clamp `contentWidth` to a minimum of 1 in `updateContent`, mirroring the existing `innerWidth` clamp in `SetSize`.
- Defensively guard the `strings.Repeat` site in `renderItem` so a negative width can never reach it again.

## Audit

I scanned the TUI for the same class of bug:

- `tree.go` — three `strings.Repeat` sites; each already gated by `if X < 1 { X = 1 }` or `if gap >= 1`. Safe.
- `stream.go::truncateContent` — already guards with `width > 0`. Safe.
- `model.go::wrappedRows` — guards `m.width <= 0`. Safe.

The only similar-class bug was the one fixed here.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` passes
- [x] New `TestStreamView_NarrowResizeDoesNotPanic` panics on the unfixed code (verified by temporarily reverting) and passes with the fix
- [ ] Manual: resize terminal narrow with tree visible — TUI no longer crashes

Closes claude-esp-5k0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)