### PR TITLE
v0.9.0: ai-title support, 1M context windows, new event types, fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ claude-esp -l
 | `j/k/↑/↓` | Navigate tree or scroll stream            |
 | `space`   | On session: collapse/expand (pins on manual expand) · On agent: toggle visibility |
 | `s`       | Solo selected session/agent (toggle)      |
+| `d`       | Remove selected session from the tree     |
 | `enter`   | Load background task output (when selected)|
 | `g/G`     | Go to top/bottom of stream                |
 | `q`       | Quit                                      |

--- a/go.mod
+++ b/go.mod
@@ -6,20 +6,20 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
+	github.com/fsnotify/fsnotify v1.9.0
+	github.com/mattn/go-runewidth v0.0.16
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -23,7 +23,8 @@ const (
 	TypeDebug         StreamItemType = "debug"          // raw line type/subtype (only emitted when DebugAll is on)
 	TypeSessionTitle  StreamItemType = "session_title"  // session label update (agent-name / custom-title)
 	TypeCacheMiss     StreamItemType = "cache_miss"     // prompt-cache invalidation (assistant.diagnostics.cache_miss_reason)
-	TypeSessionEvent  StreamItemType = "session_event"  // misc session-state change (queue-op, plan/auto mode, tool/MCP/skill deltas, permission mode)
+	TypeSessionEvent  StreamItemType = "session_event"  // misc session-state change (queue-op, plan/auto mode, tool/MCP/skill deltas, permission mode, away recap)
+	TypeAPIError      StreamItemType = "api_error"      // API request failure + retry progress (system.api_error)
 
 	// AgentIDDisplayLength is how many chars of agent ID to show in display name
 	AgentIDDisplayLength = 7
@@ -76,10 +77,16 @@ type RawMessage struct {
 	MessageCount  int             `json:"messageCount,omitempty"`
 	Message       json.RawMessage `json:"message"`
 	ToolUseResult json.RawMessage `json:"toolUseResult,omitempty"`
-	// AgentTitle and CustomTitle carry session-level labels on type="agent-name"
-	// and type="custom-title" lines respectively.
+	// AgentTitle, CustomTitle and AITitle carry session-level labels on
+	// type="agent-name", type="custom-title" and type="ai-title" lines
+	// respectively. agent-name is the legacy spelling; Claude Code now emits
+	// ai-title (which has no timestamp field).
 	AgentTitle  string `json:"agentName,omitempty"`
 	CustomTitle string `json:"customTitle,omitempty"`
+	AITitle     string `json:"aiTitle,omitempty"`
+	// PermissionMode carries the mode on type="permission-mode" lines
+	// ("default", "auto", ...).
+	PermissionMode string `json:"permissionMode,omitempty"`
 	// CompactMetadata carries trigger + preTokens on system.compact_boundary lines.
 	CompactMetadata *CompactMetadata `json:"compactMetadata,omitempty"`
 	// Attachment carries hook output / diagnostics / etc on type="attachment" lines.
@@ -89,9 +96,21 @@ type RawMessage struct {
 	PRURL        string `json:"prUrl,omitempty"`
 	PRRepository string `json:"prRepository,omitempty"`
 	// Queue-operation fields (type="queue-operation"): "enqueue" or "remove",
-	// with the queued prompt body in Content.
-	Operation    string `json:"operation,omitempty"`
-	QueueContent string `json:"content,omitempty"`
+	// with the queued prompt body in Content. Content also carries the recap
+	// text on system.away_summary lines.
+	Operation string `json:"operation,omitempty"`
+	Content   string `json:"content,omitempty"`
+	// API-error fields (system.api_error).
+	APIError     *APIErrorDetail `json:"error,omitempty"`
+	RetryAttempt int             `json:"retryAttempt,omitempty"`
+	MaxRetries   int             `json:"maxRetries,omitempty"`
+}
+
+// APIErrorDetail is the error payload on system.api_error lines.
+type APIErrorDetail struct {
+	Formatted string `json:"formatted,omitempty"` // e.g. "529 Overloaded"
+	Status    int    `json:"status,omitempty"`
+	Message   string `json:"message,omitempty"`
 }
 
 // CompactMetadata describes a conversation-compaction event.
@@ -257,6 +276,12 @@ func ParseLine(line string) ([]StreamItem, error) {
 		items = parseSessionTitle(raw, timestamp, raw.AgentTitle)
 	case "custom-title":
 		items = parseSessionTitle(raw, timestamp, raw.CustomTitle)
+	case "ai-title":
+		items = parseSessionTitle(raw, timestamp, raw.AITitle)
+	case "permission-mode":
+		if raw.PermissionMode != "" {
+			items = sessionEvent(raw, timestamp, agentDisplayName(raw.AgentID), "permission mode", raw.PermissionMode)
+		}
 	case "attachment":
 		items = parseAttachment(raw, timestamp)
 		if DebugAll && len(items) == 0 {
@@ -396,6 +421,8 @@ func nameDeltaDetail(a *Attachment) string {
 // parseQueueOperation surfaces top-level type="queue-operation" lines, which
 // CC emits when the user enqueues a follow-up prompt or removes one from the
 // queue. The enqueue carries the prompt body; the remove is a bare ack.
+// (attachment.queued_command duplicates this pair — same prompt, emitted at
+// delivery time — so it is intentionally left to the DebugAll path.)
 //
 // Enqueues whose content is a <task-notification> blob are dropped — those
 // are internal TaskStop result re-injections, not user-typed prompts.
@@ -403,10 +430,10 @@ func parseQueueOperation(raw RawMessage, timestamp time.Time) []StreamItem {
 	agentName := agentDisplayName(raw.AgentID)
 	switch raw.Operation {
 	case "enqueue":
-		if strings.HasPrefix(strings.TrimSpace(raw.QueueContent), "<task-notification>") {
+		if strings.HasPrefix(strings.TrimSpace(raw.Content), "<task-notification>") {
 			return nil
 		}
-		return sessionEvent(raw, timestamp, agentName, "queued", raw.QueueContent)
+		return sessionEvent(raw, timestamp, agentName, "queued", raw.Content)
 	case "remove":
 		return sessionEvent(raw, timestamp, agentName, "dequeued", "")
 	}
@@ -517,12 +544,28 @@ func parseSessionTitle(raw RawMessage, timestamp time.Time, title string) []Stre
 // parseSystemMessage handles system-type JSONL lines. Surfaces:
 //   - subtype=turn_duration → TypeTurnMarker (turn ended + duration)
 //   - subtype=compact_boundary → TypeCompactMarker (auto/manual compaction with preTokens)
+//   - subtype=api_error → TypeAPIError (failed API request + retry progress)
+//   - subtype=away_summary → TypeSessionEvent (while-you-were-away recap)
 //
 // Other subtypes are intentionally dropped.
 func parseSystemMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 	agentName := agentDisplayName(raw.AgentID)
 
 	switch raw.Subtype {
+	case "api_error":
+		return []StreamItem{{
+			Type:      TypeAPIError,
+			SessionID: raw.SessionID,
+			AgentID:   raw.AgentID,
+			AgentName: agentName,
+			Timestamp: timestamp,
+			Content:   formatAPIError(raw),
+		}}
+	case "away_summary":
+		if raw.Content != "" {
+			return sessionEvent(raw, timestamp, agentName, "recap", raw.Content)
+		}
+		return nil
 	case "turn_duration":
 		return []StreamItem{{
 			Type:       TypeTurnMarker,
@@ -544,6 +587,27 @@ func parseSystemMessage(raw RawMessage, timestamp time.Time) []StreamItem {
 		}}
 	}
 	return nil
+}
+
+// formatAPIError renders a system.api_error line into a short label like
+// "529 Overloaded, retry 1/10". Falls back to the raw error message (or a
+// bare status code) when the pre-formatted summary is absent.
+func formatAPIError(raw RawMessage) string {
+	var parts []string
+	if e := raw.APIError; e != nil {
+		switch {
+		case e.Formatted != "":
+			parts = append(parts, e.Formatted)
+		case e.Message != "":
+			parts = append(parts, e.Message)
+		case e.Status != 0:
+			parts = append(parts, fmt.Sprintf("status %d", e.Status))
+		}
+	}
+	if raw.RetryAttempt > 0 && raw.MaxRetries > 0 {
+		parts = append(parts, fmt.Sprintf("retry %d/%d", raw.RetryAttempt, raw.MaxRetries))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // formatCompactSummary renders compaction metadata into a short label like
@@ -582,11 +646,13 @@ func formatTokenCount(n int64) string {
 // releases of the same family resolve correctly.
 func ContextWindowFor(model string) int64 {
 	switch {
-	case strings.HasPrefix(model, "claude-opus-4-7"),
+	case strings.HasPrefix(model, "claude-fable-5"),
+		strings.HasPrefix(model, "claude-opus-4-8"),
+		strings.HasPrefix(model, "claude-opus-4-7"),
+		strings.HasPrefix(model, "claude-opus-4-6"),
 		strings.HasPrefix(model, "claude-sonnet-4-6"):
 		return 1_000_000
 	case strings.HasPrefix(model, "claude-haiku-4-5"),
-		strings.HasPrefix(model, "claude-opus-4-6"),
 		strings.HasPrefix(model, "claude-sonnet-4-5"),
 		strings.HasPrefix(model, "claude-haiku-4"):
 		return 200_000

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -897,3 +897,112 @@ func TestParseLine_SkillListing_UpdateSurfaces(t *testing.T) {
 		t.Errorf("content = %q, want %q", items[0].Content, "50 total")
 	}
 }
+
+func TestParseLine_SessionTitleAITitle(t *testing.T) {
+	// Claude Code renamed agent-name → ai-title; the new lines carry the
+	// label in aiTitle and have no timestamp field.
+	line := `{"type":"ai-title","aiTitle":"Understand pat search functionality","sessionId":"sess-3"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 title item, got %d", len(items))
+	}
+	if items[0].Type != TypeSessionTitle {
+		t.Errorf("type = %q, want %q", items[0].Type, TypeSessionTitle)
+	}
+	if items[0].Content != "Understand pat search functionality" {
+		t.Errorf("content = %q", items[0].Content)
+	}
+	if items[0].SessionID != "sess-3" {
+		t.Errorf("sessionID = %q, want sess-3", items[0].SessionID)
+	}
+}
+
+func TestParseLine_AITitleEmptyDropped(t *testing.T) {
+	line := `{"type":"ai-title","aiTitle":"","sessionId":"sess-3"}`
+	items, _ := ParseLine(line)
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items for empty ai-title, got %+v", items)
+	}
+}
+
+func TestParseLine_PermissionMode(t *testing.T) {
+	line := `{"type":"permission-mode","permissionMode":"auto","sessionId":"s"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeSessionEvent {
+		t.Fatalf("expected 1 session event, got %+v", items)
+	}
+	if items[0].ToolName != "permission mode" || items[0].Content != "auto" {
+		t.Errorf("got label=%q detail=%q, want permission mode/auto", items[0].ToolName, items[0].Content)
+	}
+}
+
+func TestParseLine_APIError(t *testing.T) {
+	line := `{"type":"system","subtype":"api_error","sessionId":"s","timestamp":"2026-06-01T12:00:00Z","error":{"message":"529 overloaded_error","status":529,"formatted":"529 Overloaded"},"retryInMs":559.6,"retryAttempt":1,"maxRetries":10}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeAPIError {
+		t.Fatalf("expected 1 api_error item, got %+v", items)
+	}
+	if items[0].Content != "529 Overloaded, retry 1/10" {
+		t.Errorf("content = %q, want %q", items[0].Content, "529 Overloaded, retry 1/10")
+	}
+}
+
+func TestParseLine_APIError_MessageFallback(t *testing.T) {
+	line := `{"type":"system","subtype":"api_error","sessionId":"s","timestamp":"2026-06-01T12:00:00Z","error":{"message":"connection reset"}}`
+	items, _ := ParseLine(line)
+	if len(items) != 1 || items[0].Content != "connection reset" {
+		t.Fatalf("expected message fallback, got %+v", items)
+	}
+}
+
+func TestParseLine_AwaySummary(t *testing.T) {
+	line := `{"type":"system","subtype":"away_summary","sessionId":"s","timestamp":"2026-06-01T12:00:00Z","content":"Built the thing. Next: ship it."}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeSessionEvent {
+		t.Fatalf("expected 1 session event, got %+v", items)
+	}
+	if items[0].ToolName != "recap" || items[0].Content != "Built the thing. Next: ship it." {
+		t.Errorf("got label=%q detail=%q", items[0].ToolName, items[0].Content)
+	}
+}
+
+func TestParseLine_AwaySummary_EmptyDropped(t *testing.T) {
+	line := `{"type":"system","subtype":"away_summary","sessionId":"s","timestamp":"2026-06-01T12:00:00Z"}`
+	items, _ := ParseLine(line)
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items, got %+v", items)
+	}
+}
+
+func TestContextWindowFor(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int64
+	}{
+		{"claude-fable-5", 1_000_000},
+		{"claude-opus-4-8", 1_000_000},
+		{"claude-opus-4-7", 1_000_000},
+		{"claude-opus-4-6", 1_000_000},
+		{"claude-sonnet-4-6", 1_000_000},
+		{"claude-haiku-4-5-20251001", 200_000},
+		{"claude-sonnet-4-5", 200_000},
+		{"some-unknown-model", 200_000},
+	}
+	for _, tt := range tests {
+		if got := ContextWindowFor(tt.model); got != tt.want {
+			t.Errorf("ContextWindowFor(%q) = %d, want %d", tt.model, got, tt.want)
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -286,6 +286,19 @@ func (m *Model) handleKey(msg tea.KeyMsg) tea.Cmd {
 	case "x":
 		m.stream.ToggleText()
 
+	case "d":
+		// Remove the selected session from the tree and the watcher. The
+		// watcher remembers the ID so auto-discovery doesn't re-add it.
+		if m.focus == FocusTree {
+			if sessionID := m.tree.GetSelectedSession(); sessionID != "" {
+				m.tree.RemoveSession(sessionID)
+				if m.watcher != nil {
+					m.watcher.RemoveSession(sessionID)
+				}
+				m.stream.SetEnabledFilters(m.tree.GetEnabledFilters())
+			}
+		}
+
 	case "s":
 		if m.focus == FocusTree {
 			m.tree.Solo()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -626,7 +626,7 @@ func (m *Model) renderStreamOnly() string {
 func (m *Model) renderHelp() string {
 	var help string
 	if m.focus == FocusTree {
-		help = "j/k: navigate │ space: toggle │ s: solo │ A: auto-discover │ q: quit"
+		help = "j/k: navigate │ space: toggle │ s: solo │ d: remove │ A: auto-discover │ q: quit"
 	} else {
 		help = "j/k: scroll │ g/G: top/bottom │ A: auto-discover │ tab: tree │ q: quit"
 	}

--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -21,7 +21,8 @@ const (
 type StreamView struct {
 	viewport    viewport.Model
 	items       []parser.StreamItem
-	seenToolIDs map[string]bool // dedupe tool input/output by ToolID
+	seenToolIDs map[string]bool   // dedupe tool input/output by ToolID
+	toolNames   map[string]string // ToolID → tool name, for labeling outputs in O(1)
 	width       int
 	height      int
 	autoScroll  bool
@@ -44,6 +45,7 @@ func NewStreamView() *StreamView {
 		viewport:       vp,
 		items:          make([]parser.StreamItem, 0),
 		seenToolIDs:    make(map[string]bool),
+		toolNames:      make(map[string]string),
 		autoScroll:     true,
 		maxLines:       MaxLinesPerItem,
 		showThinking:   true,
@@ -92,14 +94,35 @@ func (s *StreamView) AddItem(item parser.StreamItem) {
 			return // Skip duplicate
 		}
 		s.seenToolIDs[dedupKey] = true
+		if item.Type == parser.TypeToolInput && item.ToolName != "" {
+			s.toolNames[item.ToolID] = item.ToolName
+		}
 	}
 
 	s.items = append(s.items, item)
 	// Keep last MaxStreamItems items to prevent memory issues
 	if len(s.items) > MaxStreamItems {
 		s.items = s.items[len(s.items)-MaxStreamItems:]
+		s.rebuildToolIndexes()
 	}
 	s.updateContent()
+}
+
+// rebuildToolIndexes recreates seenToolIDs and toolNames from the surviving
+// items after truncation. Without this both maps grow without bound in
+// long-running sessions: entries for evicted items are never released.
+func (s *StreamView) rebuildToolIndexes() {
+	s.seenToolIDs = make(map[string]bool, len(s.items))
+	s.toolNames = make(map[string]string, len(s.items))
+	for _, it := range s.items {
+		if it.ToolID == "" {
+			continue
+		}
+		s.seenToolIDs[fmt.Sprintf("%s:%s", it.ToolID, it.Type)] = true
+		if it.Type == parser.TypeToolInput && it.ToolName != "" {
+			s.toolNames[it.ToolID] = it.ToolName
+		}
+	}
 }
 
 // SetEnabledFilters updates which session/agent combos are visible
@@ -251,6 +274,13 @@ func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
 		}
 		return mutedStyle.Render(text)
 	}
+	if item.Type == parser.TypeAPIError {
+		text := "── API error ──"
+		if item.Content != "" {
+			text = fmt.Sprintf("── API error: %s ──", oneLineSnippet(item.Content, 80))
+		}
+		return apiErrorStyle.Render(text)
+	}
 	if item.Type == parser.TypeSessionEvent {
 		label := item.ToolName
 		if label == "" {
@@ -289,16 +319,8 @@ func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
 		b.WriteString(toolInputContentStyle.Render(content))
 
 	case parser.TypeToolOutput:
-		// Look up tool name from matching ToolInput
-		toolName := ""
-		if item.ToolID != "" {
-			for _, other := range s.items {
-				if other.Type == parser.TypeToolInput && other.ToolID == item.ToolID {
-					toolName = other.ToolName
-					break
-				}
-			}
-		}
+		// Look up tool name from the matching ToolInput's index entry
+		toolName := s.toolNames[item.ToolID]
 		var outputLabel string
 		if toolName != "" {
 			outputLabel = toolOutputIcon + " " + toolName + " result"

--- a/internal/tui/stream_test.go
+++ b/internal/tui/stream_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -292,5 +293,60 @@ func TestStreamView_ToggleStates(t *testing.T) {
 	s.ToggleToolOutput()
 	if s.IsToolOutputEnabled() {
 		t.Error("tool output should be disabled after toggle")
+	}
+}
+
+func TestStreamView_ToolIndexesPrunedOnTruncation(t *testing.T) {
+	s := NewStreamView()
+	s.SetSize(80, 24)
+
+	// Push well past MaxStreamItems with unique tool IDs; the dedup and
+	// name indexes must track only the surviving items, not grow forever.
+	for i := 0; i < MaxStreamItems+500; i++ {
+		item := newTestItem(parser.TypeToolInput, "sess1", "", "input")
+		item.ToolID = fmt.Sprintf("tool-%d", i)
+		item.ToolName = "Bash"
+		s.AddItem(item)
+	}
+
+	if len(s.items) != MaxStreamItems {
+		t.Fatalf("expected %d items, got %d", MaxStreamItems, len(s.items))
+	}
+	if len(s.seenToolIDs) > MaxStreamItems {
+		t.Errorf("seenToolIDs grew unboundedly: %d entries for %d items", len(s.seenToolIDs), len(s.items))
+	}
+	if len(s.toolNames) > MaxStreamItems {
+		t.Errorf("toolNames grew unboundedly: %d entries for %d items", len(s.toolNames), len(s.items))
+	}
+}
+
+func TestStreamView_ToolOutputLabelFromIndex(t *testing.T) {
+	s := NewStreamView()
+	s.SetSize(80, 24)
+	s.SetEnabledFilters([]EnabledFilter{{SessionID: "sess1", AgentID: ""}})
+
+	in := newTestItem(parser.TypeToolInput, "sess1", "", "ls")
+	in.ToolID = "t1"
+	in.ToolName = "Bash"
+	s.AddItem(in)
+
+	out := newTestItem(parser.TypeToolOutput, "sess1", "", "file.txt")
+	out.ToolID = "t1"
+	s.AddItem(out)
+
+	rendered := s.renderItem(out, 76)
+	if !strings.Contains(rendered, "Bash result") {
+		t.Errorf("expected output labeled with tool name, got %q", rendered)
+	}
+}
+
+func TestStreamView_APIErrorMarker(t *testing.T) {
+	s := NewStreamView()
+	s.SetSize(80, 24)
+
+	item := newTestItem(parser.TypeAPIError, "sess1", "", "529 Overloaded, retry 1/10")
+	rendered := s.renderItem(item, 76)
+	if !strings.Contains(rendered, "API error: 529 Overloaded, retry 1/10") {
+		t.Errorf("unexpected api error rendering: %q", rendered)
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -122,6 +122,10 @@ var (
 	// Muted text style (for truncation messages etc)
 	mutedStyle = lipgloss.NewStyle().
 			Foreground(mutedColor)
+
+	// API error marker - red, so failed/retrying requests stand out
+	apiErrorStyle = lipgloss.NewStyle().
+			Foreground(errorColor)
 )
 
 // Helper to truncate strings

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mattn/go-runewidth"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // NodeType indicates the type of tree node
@@ -776,10 +776,11 @@ func (t *TreeView) View() string {
 			if lineLen < innerWidth {
 				line += strings.Repeat(" ", innerWidth-lineLen)
 			} else if lineLen > innerWidth {
-				// Truncate over-wide lines rune-by-rune so we stop at
-				// exactly innerWidth visible columns. Preserves ANSI
-				// escape sequences that precede the visible runes.
-				line = runewidth.Truncate(stripAnsi(line), innerWidth, "…")
+				// ansi.Truncate is escape-aware: it cuts at exactly
+				// innerWidth visible columns while keeping the line's
+				// styling intact (the old stripAnsi+runewidth.Truncate
+				// dropped all color from truncated lines).
+				line = ansi.Truncate(line, innerWidth, "…")
 			}
 		}
 
@@ -847,32 +848,13 @@ func contextSuffix(node *TreeNode) string {
 	return fmt.Sprintf("%d%%", pct)
 }
 
-// lipglossWidth calculates visible width accounting for ANSI codes
+// lipglossWidth calculates visible width accounting for ANSI codes.
+// ansi.StringWidth handles CSI/OSC escape sequences (the previous hand-rolled
+// stripper missed OSC) and East Asian wide characters / emoji, which occupy
+// 2 terminal columns despite being 1 rune. len([]rune(s)) would undercount
+// lines with 💤/📁/💬/🤖/✓/⏳ icons, causing them to be padded too short and
+// then wrap in the terminal — which made the tree taller than its assigned
+// height and overflowed the viewport, clipping the top of the TUI.
 func lipglossWidth(s string) int {
-	// runewidth.StringWidth correctly handles East Asian wide characters
-	// and emoji (which occupy 2 terminal columns despite being 1 rune).
-	// len([]rune(s)) would undercount lines with 💤/📁/💬/🤖/✓/⏳ icons,
-	// causing them to be padded too short and then wrap in the terminal —
-	// which made the tree taller than its assigned height and overflowed
-	// the viewport, clipping the top of the TUI.
-	return runewidth.StringWidth(stripAnsi(s))
-}
-
-func stripAnsi(s string) string {
-	var result strings.Builder
-	inEscape := false
-	for _, r := range s {
-		if r == '\x1b' {
-			inEscape = true
-			continue
-		}
-		if inEscape {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEscape = false
-			}
-			continue
-		}
-		result.WriteRune(r)
-	}
-	return result.String()
+	return ansi.StringWidth(s)
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -166,7 +166,8 @@ type Watcher struct {
 	claudeDir         string
 	pollInterval      time.Duration
 	sessions          map[string]*Session
-	sessionsMu        sync.RWMutex     // protects sessions map
+	removed           map[string]bool  // session IDs removed by the user; never re-discovered
+	sessionsMu        sync.RWMutex     // protects sessions and removed maps
 	filePositions     map[string]int64 // track read position per file
 	filePosMu         sync.RWMutex     // protects filePositions map
 	Items             chan parser.StreamItem
@@ -213,6 +214,7 @@ func New(sessionID string, pollInterval time.Duration, activeWindow time.Duratio
 		claudeDir:         claudeDir,
 		pollInterval:      pollInterval,
 		sessions:          make(map[string]*Session),
+		removed:           make(map[string]bool),
 		filePositions:     make(map[string]int64),
 		Items:             make(chan parser.StreamItem, ItemChannelBuffer),
 		Errors:            make(chan error, ErrorChannelBuffer),
@@ -390,9 +392,16 @@ func (w *Watcher) discoverActiveSessions() error {
 		discovered = discovered[:w.maxSessions]
 	}
 
+	// Hold the lock: this also runs from the fsnotify goroutine (via
+	// handleFsCreate) after Start, concurrently with readers.
+	w.sessionsMu.Lock()
 	for _, d := range discovered {
+		if w.removed[d.session.ID] {
+			continue
+		}
 		w.sessions[d.session.ID] = d.session
 	}
+	w.sessionsMu.Unlock()
 
 	return err
 }
@@ -402,10 +411,12 @@ func (w *Watcher) SetSkipHistory(skip bool) {
 	w.skipHistory.Store(skip)
 }
 
-// RemoveSession removes a session from being watched
+// RemoveSession removes a session from being watched and marks it so
+// auto-discovery (polling or fsnotify) doesn't immediately re-add it.
 func (w *Watcher) RemoveSession(sessionID string) {
 	w.sessionsMu.Lock()
 	delete(w.sessions, sessionID)
+	w.removed[sessionID] = true
 	w.sessionsMu.Unlock()
 }
 
@@ -1018,7 +1029,7 @@ func (w *Watcher) handleNewSessionFile(path string) {
 	}
 
 	w.sessionsMu.Lock()
-	if _, exists := w.sessions[session.ID]; exists {
+	if _, exists := w.sessions[session.ID]; exists || w.removed[session.ID] {
 		w.sessionsMu.Unlock()
 		return
 	}
@@ -1209,9 +1220,10 @@ func (w *Watcher) checkForNewSessions() {
 
 		w.sessionsMu.RLock()
 		_, exists := w.sessions[id]
+		removed := w.removed[id]
 		w.sessionsMu.RUnlock()
 
-		if exists {
+		if exists || removed {
 			return nil
 		}
 
@@ -1358,21 +1370,27 @@ func (w *Watcher) skipToEndOfFiles(session *Session) {
 
 // findPositionForLastNLines returns the byte offset to start reading the last N lines
 func findPositionForLastNLines(path string, n int) int64 {
+	if n <= 0 {
+		return 0
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		return 0
 	}
 	defer file.Close()
 
-	// Collect positions of all newlines
-	var newlinePositions []int64
+	// Track only the last n newline positions in a ring buffer — keeps
+	// memory O(n) instead of one offset per line in the whole file.
+	ring := make([]int64, n)
+	var count int64
 	var pos int64
 	buf := make([]byte, FileReadBufferSize)
 	for {
 		bytesRead, err := file.Read(buf)
 		for i := 0; i < bytesRead; i++ {
 			if buf[i] == '\n' {
-				newlinePositions = append(newlinePositions, pos+int64(i)+1)
+				ring[count%int64(n)] = pos + int64(i) + 1
+				count++
 			}
 		}
 		pos += int64(bytesRead)
@@ -1382,12 +1400,13 @@ func findPositionForLastNLines(path string, n int) int64 {
 	}
 
 	// If fewer than N lines, start from beginning
-	if len(newlinePositions) <= n {
+	if count <= int64(n) {
 		return 0
 	}
 
-	// Return position after the newline that's N lines from the end
-	return newlinePositions[len(newlinePositions)-n]
+	// Return position after the newline that's N lines from the end:
+	// the oldest entry still in the ring.
+	return ring[count%int64(n)]
 }
 
 func (w *Watcher) readSessionFiles(session *Session) {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	version = "0.8.0"
+	version = "0.9.0"
 )
 
 func main() {
@@ -169,7 +169,8 @@ KEYBINDINGS:
     a           Toggle auto-scroll
     h           Hide/show tree pane
     A           Toggle auto-discovery of new sessions
-    x/d         Remove selected session (in tree)
+    x           Toggle text (response) visibility
+    d           Remove selected session (in tree)
     tab         Switch focus between tree and stream
     j/k         Navigate (tree) or scroll (stream)
     space       On agent: toggle visibility · On session: collapse/expand (pins on manual expand)


### PR DESCRIPTION
## Summary

Batched v0.9.0 release: catch up with Claude Code JSONL format changes since v0.8.0, plus bug fixes and perf improvements from a general review. Mirrored in claude-esp-rs.

### Claude Code format updates
- **Handle `type=ai-title` lines** — Claude Code replaced `agent-name` lines with `{"type":"ai-title","aiTitle":"..."}`; session titles were silently broken for all new sessions. Empty titles are dropped.
- **Surface `system.api_error`** — rendered as a single red divider with retry progress (e.g. `── API error: 529 Overloaded, retry 1/10 ──`), falling back to the error message or status code.
- **Surface `permission-mode` lines and `system.away_summary`** as muted session events.
- **Context windows**: add `claude-fable-5` and `claude-opus-4-8` at 1M, and move `claude-opus-4-6` to 1M per the current model catalog (empirically confirmed — observed opus-4-8 sessions at 367k real tokens).

Intentionally skipped: `attachment.queued_command` duplicates the existing `queue-operation` lines (same prompt, emitted at delivery time), so it stays on the DebugAll path only.

### Fixes
- **Data race in the watcher** — `discoverActiveSessions` wrote `w.sessions` without holding `sessionsMu` while being callable from the fsnotify goroutine; now locked. Verified with `go test -race`.
- **Broken remove keybinding** — help advertised `x/d` for removing a session, but `x` toggles text visibility and `d` did nothing. `d` now removes the selected session from the tree, and the watcher remembers removed IDs so auto-discovery doesn't immediately re-add them.
- **Unbounded map growth** — `seenToolIDs` (and the new tool-name index) are rebuilt when the stream truncates, instead of growing forever in long-running sessions.
- `findPositionForLastNLines` rewritten with a ring buffer and a guard for `n <= 0`.

### Perf / cleanup
- O(1) `toolID→name` index replaces an O(n) scan over all stream items per rendered tool output.
- Tree truncation now uses escape-aware `ansi.Truncate`/`ansi.StringWidth` from `charmbracelet/x/ansi` (keeps styling intact at narrow widths); hand-rolled `stripAnsi` deleted.

## Test plan
- [x] `go test -race ./...` — all packages pass
- [x] `go vet`, `gofmt` clean
- [x] New parser tests for ai-title, permission-mode, api_error (+ message fallback), away_summary, context windows
- [x] New stream tests for index pruning on truncation, tool-output labels, API-error marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)