### PR TITLE
v0.12.0: surface cost-state, frame-link, continued-in, task_status; tool formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When using Claude Code interactively, tool outputs and thinking are collapsed by
 - **Hierarchical tree view** - Sessions with nested Main/Agent nodes
 - **Real-time streaming** - See thinking, tool calls, and outputs as they happen
 - **Subagent tracking** - Automatically discovers and displays subagent activity
-- **Session events** - Compaction boundaries, hook output, post-edit LSP diagnostics, PR-link events, prompt-cache misses (with reason + extra tokens), queue operations, slash-command invocations, transient notices, killed-subagent markers, plan/auto mode transitions, permission-mode changes, and skill/MCP/tool deltas surfaced inline
+- **Session events** - Compaction boundaries, hook output, post-edit LSP diagnostics, PR-link and artifact-link events, session-cost summaries (cost, lines changed, models used), session continuations, background-task progress, prompt-cache misses (with reason + extra tokens), queue operations, slash-command invocations, transient notices, killed-subagent markers, plan/auto mode transitions, permission-mode changes, and skill/MCP/tool deltas surfaced inline
 - **Agent type labels** - Shows agent types (Explore, code-reviewer, etc.) from `.meta.json`
 - **Token usage tracking** - Cumulative input/output token counts in the header bar
 - **Per-agent context size** - Each Main/subagent row shows current context as a percentage of the model's max context window (`Main 18%`, `Explore 9%`). Denominator is the model's *max window* (1M for the Claude 5 family and opus-4-6 through 4-8 / sonnet-4-6, 200k for haiku-4-5), **not** the auto-compact threshold

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -26,6 +28,7 @@ const (
 	TypeCacheMiss     StreamItemType = "cache_miss"     // prompt-cache invalidation (assistant.diagnostics.cache_miss_reason)
 	TypeSessionEvent  StreamItemType = "session_event"  // misc session-state change (queue-op, plan/auto mode, tool/MCP/skill deltas, permission mode, away recap)
 	TypeAPIError      StreamItemType = "api_error"      // API request failure + retry progress (system.api_error)
+	TypeArtifactLink  StreamItemType = "artifact_link"  // artifact published to claude.ai (type=frame-link)
 
 	// AgentIDDisplayLength is how many chars of agent ID to show in display name
 	AgentIDDisplayLength = 7
@@ -107,6 +110,27 @@ type RawMessage struct {
 	APIError     *APIErrorDetail `json:"error,omitempty"`
 	RetryAttempt int             `json:"retryAttempt,omitempty"`
 	MaxRetries   int             `json:"maxRetries,omitempty"`
+	// Artifact-link fields (type="frame-link"). Only the first line for an
+	// artifact carries the URL and title; follow-ups carry just ArtifactCount.
+	FrameURL      string `json:"frameUrl,omitempty"`
+	Title         string `json:"title,omitempty"`
+	ArtifactCount int    `json:"artifactCount,omitempty"`
+	// ContinuedInSessionID is the successor session on type="continued-in".
+	ContinuedInSessionID string `json:"continuedInSessionId,omitempty"`
+	// Cost-state fields (type="cost-state"), written at session end. The
+	// line has no timestamp; StartTime+TotalDuration (both ms) reconstructs it.
+	TotalCostUSD      float64               `json:"totalCostUSD,omitempty"`
+	TotalLinesAdded   int64                 `json:"totalLinesAdded,omitempty"`
+	TotalLinesRemoved int64                 `json:"totalLinesRemoved,omitempty"`
+	TotalDuration     int64                 `json:"totalDuration,omitempty"`
+	StartTime         int64                 `json:"startTime,omitempty"`
+	ModelUsage        map[string]ModelUsage `json:"modelUsage,omitempty"`
+}
+
+// ModelUsage is one model's entry in cost-state.modelUsage. Only the cost is
+// read; token counts are already tracked per assistant message.
+type ModelUsage struct {
+	CostUSD float64 `json:"costUSD,omitempty"`
 }
 
 // APIErrorDetail is the error payload on system.api_error lines.
@@ -147,6 +171,11 @@ type Attachment struct {
 	// skill_listing
 	SkillCount int  `json:"skillCount,omitempty"`
 	IsInitial  bool `json:"isInitial,omitempty"`
+	// task_status (background subagent progress)
+	TaskID       string `json:"taskId,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Status       string `json:"status,omitempty"`
+	DeltaSummary string `json:"deltaSummary,omitempty"`
 }
 
 // DiagnosticFile is one file's worth of LSP diagnostics.
@@ -242,6 +271,22 @@ type ToolInput struct {
 	TaskID       string `json:"taskId,omitempty"`
 	TaskIDSnake  string `json:"task_id,omitempty"`
 	Cron         string `json:"cron,omitempty"`
+	// SendUserFile
+	Files   []string `json:"files,omitempty"`
+	Caption string   `json:"caption,omitempty"`
+	// AskUserQuestion
+	Questions []ToolInputQuestion `json:"questions,omitempty"`
+	// SendMessage
+	To      string `json:"to,omitempty"`
+	Message string `json:"message,omitempty"`
+	// Artifact
+	Action string `json:"action,omitempty"`
+	URL    string `json:"url,omitempty"`
+}
+
+// ToolInputQuestion is one entry in AskUserQuestion's questions array.
+type ToolInputQuestion struct {
+	Question string `json:"question"`
 }
 
 // ParseLine parses a single JSONL line and returns stream items
@@ -292,6 +337,17 @@ func ParseLine(line string) ([]StreamItem, error) {
 		}
 	case "pr-link":
 		items = parsePRLink(raw, timestamp)
+	case "frame-link":
+		items = parseFrameLink(raw, timestamp)
+		if DebugAll && len(items) == 0 {
+			items = []StreamItem{debugItem(raw, line, timestamp)}
+		}
+	case "continued-in":
+		if raw.ContinuedInSessionID != "" {
+			items = sessionEvent(raw, timestamp, agentDisplayName(raw.AgentID), "continued in", raw.ContinuedInSessionID)
+		}
+	case "cost-state":
+		items = parseCostState(raw, timestamp)
 	case "queue-operation":
 		items = parseQueueOperation(raw, timestamp)
 	default:
@@ -379,8 +435,33 @@ func parseAttachment(raw RawMessage, timestamp time.Time) []StreamItem {
 		if !raw.Attachment.IsInitial && raw.Attachment.SkillCount > 0 {
 			return sessionEvent(raw, timestamp, agentName, "skills", fmt.Sprintf("%d total", raw.Attachment.SkillCount))
 		}
+	case "task_status":
+		// Background subagent progress: "task running: <description> — <delta>".
+		if detail := taskStatusDetail(raw.Attachment); detail != "" {
+			label := "task"
+			if raw.Attachment.Status != "" {
+				label = "task " + raw.Attachment.Status
+			}
+			return sessionEvent(raw, timestamp, agentName, label, detail)
+		}
 	}
 	return nil
+}
+
+// taskStatusDetail joins a task_status attachment's description and delta
+// summary. Returns "" when both are empty (caller should drop the event).
+func taskStatusDetail(a *Attachment) string {
+	if a == nil {
+		return ""
+	}
+	switch {
+	case a.Description != "" && a.DeltaSummary != "":
+		return a.Description + " — " + a.DeltaSummary
+	case a.Description != "":
+		return a.Description
+	default:
+		return a.DeltaSummary
+	}
 }
 
 // sessionEvent builds a TypeSessionEvent marker. label goes in ToolName so
@@ -533,6 +614,83 @@ func parsePRLink(raw RawMessage, timestamp time.Time) []StreamItem {
 		Timestamp: timestamp,
 		Content:   content,
 	}}
+}
+
+// parseFrameLink surfaces type="frame-link" lines, written when the Artifact
+// tool publishes a page to claude.ai. The first line for an artifact carries
+// its title and URL; later lines (redeploys, watch bookkeeping) carry only an
+// artifact count and are dropped.
+func parseFrameLink(raw RawMessage, timestamp time.Time) []StreamItem {
+	if raw.FrameURL == "" {
+		return nil
+	}
+	content := "artifact → " + raw.FrameURL
+	if raw.Title != "" {
+		content = fmt.Sprintf("artifact %q → %s", raw.Title, raw.FrameURL)
+	}
+	return []StreamItem{{
+		Type:      TypeArtifactLink,
+		SessionID: raw.SessionID,
+		Timestamp: timestamp,
+		Content:   content,
+	}}
+}
+
+// parseCostState surfaces type="cost-state" lines as a session-cost marker:
+// "$13.75 · +1003/-168 lines · opus-5 sonnet-5 haiku-4-5". Claude Code
+// writes the line at session end without a timestamp, so the event time is
+// reconstructed from startTime + totalDuration when both are present.
+func parseCostState(raw RawMessage, fallback time.Time) []StreamItem {
+	if raw.TotalCostUSD == 0 && len(raw.ModelUsage) == 0 {
+		return nil
+	}
+	timestamp := fallback
+	if raw.StartTime > 0 && raw.TotalDuration > 0 {
+		timestamp = time.UnixMilli(raw.StartTime + raw.TotalDuration)
+	}
+	parts := []string{fmt.Sprintf("$%.2f", raw.TotalCostUSD)}
+	if raw.TotalLinesAdded > 0 || raw.TotalLinesRemoved > 0 {
+		parts = append(parts, fmt.Sprintf("+%d/-%d lines", raw.TotalLinesAdded, raw.TotalLinesRemoved))
+	}
+	if names := costStateModels(raw.ModelUsage); names != "" {
+		parts = append(parts, names)
+	}
+	return sessionEvent(raw, timestamp, agentDisplayName(raw.AgentID), "session cost", strings.Join(parts, " · "))
+}
+
+// costStateModels lists the models in a cost-state entry, most expensive
+// first, with the "claude-" prefix and any dated suffix stripped so the
+// marker stays short: "opus-5 sonnet-5 haiku-4-5".
+func costStateModels(usage map[string]ModelUsage) string {
+	if len(usage) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(usage))
+	for name := range usage {
+		names = append(names, name)
+	}
+	sort.SliceStable(names, func(i, j int) bool {
+		ci, cj := usage[names[i]].CostUSD, usage[names[j]].CostUSD
+		if ci != cj {
+			return ci > cj
+		}
+		return names[i] < names[j]
+	})
+	for i, name := range names {
+		names[i] = shortModelName(name)
+	}
+	return strings.Join(names, " ")
+}
+
+// shortModelName turns "claude-haiku-4-5-20251001" into "haiku-4-5".
+func shortModelName(model string) string {
+	name := strings.TrimPrefix(model, "claude-")
+	if i := strings.LastIndex(name, "-"); i > 0 && len(name)-i-1 == 8 {
+		if _, err := time.Parse("20060102", name[i+1:]); err == nil {
+			name = name[:i]
+		}
+	}
+	return name
 }
 
 // parseSessionTitle emits a TypeSessionTitle item carrying a human-readable
@@ -883,7 +1041,8 @@ func formatToolInput(toolName string, inputRaw json.RawMessage) string {
 	}
 
 	switch toolName {
-	case "Bash":
+	case "Bash", "Monitor":
+		// Monitor shares Bash's shape: a shell command plus a description.
 		if input.Description != "" {
 			return fmt.Sprintf("%s\n  # %s", input.Command, input.Description)
 		}
@@ -947,6 +1106,56 @@ func formatToolInput(toolName string, inputRaw json.RawMessage) string {
 			return fmt.Sprintf("%s: %s", input.Cron, input.Prompt)
 		}
 		return string(inputRaw)
+	case "SendUserFile":
+		names := make([]string, 0, len(input.Files))
+		for _, f := range input.Files {
+			names = append(names, filepath.Base(f))
+		}
+		files := strings.Join(names, ", ")
+		switch {
+		case files != "" && input.Caption != "":
+			return fmt.Sprintf("%s\n  # %s", files, input.Caption)
+		case files != "":
+			return files
+		case input.Caption != "":
+			return input.Caption
+		}
+		return string(inputRaw)
+	case "AskUserQuestion":
+		questions := make([]string, 0, len(input.Questions))
+		for _, q := range input.Questions {
+			if q.Question != "" {
+				questions = append(questions, q.Question)
+			}
+		}
+		if len(questions) > 0 {
+			return strings.Join(questions, "\n")
+		}
+		return string(inputRaw)
+	case "SendMessage":
+		if input.To != "" {
+			return fmt.Sprintf("→ %s: %s", input.To, input.Message)
+		}
+		if input.Message != "" {
+			return input.Message
+		}
+		return string(inputRaw)
+	case "ListAgents":
+		return "(list agents)"
+	case "Artifact":
+		action := input.Action
+		if action == "" {
+			action = "publish"
+		}
+		switch {
+		case input.FilePath != "" && input.URL != "":
+			return fmt.Sprintf("%s %s → %s", action, input.FilePath, input.URL)
+		case input.FilePath != "":
+			return fmt.Sprintf("%s %s", action, input.FilePath)
+		case input.URL != "":
+			return fmt.Sprintf("%s %s", action, input.URL)
+		}
+		return action
 	default:
 		return string(inputRaw)
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1120,3 +1120,214 @@ func TestDebugPreviewCJKNeverSplitsRune(t *testing.T) {
 		}
 	}
 }
+
+// --- v0.12.0: frame-link, continued-in, cost-state, task_status ---
+
+func TestParseLine_FrameLink(t *testing.T) {
+	line := `{"type":"frame-link","sessionId":"4f9aca60","path":"/tmp/scratch/marblemath.html","frameUrl":"https://claude.ai/code/artifact/d9254fd4-fadd-49af-a025-b168723f9530","title":"MarbleMath","artifactCount":1,"timestamp":"2026-08-23T21:59:11.397Z"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeArtifactLink {
+		t.Fatalf("expected 1 artifact_link item, got %+v", items)
+	}
+	want := `artifact "MarbleMath" → https://claude.ai/code/artifact/d9254fd4-fadd-49af-a025-b168723f9530`
+	if items[0].Content != want {
+		t.Errorf("content = %q, want %q", items[0].Content, want)
+	}
+	if items[0].SessionID != "4f9aca60" {
+		t.Errorf("sessionID = %q", items[0].SessionID)
+	}
+}
+
+func TestParseLine_FrameLink_NoTitle(t *testing.T) {
+	line := `{"type":"frame-link","sessionId":"s","frameUrl":"https://claude.ai/code/artifact/abc","artifactCount":1,"timestamp":"2026-08-23T21:59:11.397Z"}`
+	items, _ := ParseLine(line)
+	if len(items) != 1 || items[0].Content != "artifact → https://claude.ai/code/artifact/abc" {
+		t.Fatalf("got %+v", items)
+	}
+}
+
+func TestParseLine_FrameLink_CountOnlyDropped(t *testing.T) {
+	// Redeploys and watch bookkeeping re-emit frame-link with only a count.
+	line := `{"type":"frame-link","artifactCount":1,"sessionId":"s","timestamp":"2026-08-23T22:06:10.001Z"}`
+	items, _ := ParseLine(line)
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items, got %+v", items)
+	}
+}
+
+func TestParseLine_FrameLink_CountOnlyDebug(t *testing.T) {
+	prev := DebugAll
+	DebugAll = true
+	t.Cleanup(func() { DebugAll = prev })
+
+	line := `{"type":"frame-link","artifactCount":1,"sessionId":"s","timestamp":"2026-08-23T22:06:10.001Z"}`
+	items, _ := ParseLine(line)
+	if len(items) != 1 || items[0].Type != TypeDebug || items[0].ToolName != "frame-link" {
+		t.Fatalf("expected 1 debug item labelled frame-link, got %+v", items)
+	}
+}
+
+func TestParseLine_ContinuedIn(t *testing.T) {
+	line := `{"type":"continued-in","timestamp":"2026-09-04T21:38:04.469Z","sessionId":"d2bf19dc","continuedInSessionId":"6ee341a1-87cb-4157-a678-ceafb0bd48c6"}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeSessionEvent {
+		t.Fatalf("expected 1 session event, got %+v", items)
+	}
+	if items[0].ToolName != "continued in" || items[0].Content != "6ee341a1-87cb-4157-a678-ceafb0bd48c6" {
+		t.Errorf("got label=%q detail=%q", items[0].ToolName, items[0].Content)
+	}
+}
+
+func TestParseLine_ContinuedIn_EmptyDropped(t *testing.T) {
+	line := `{"type":"continued-in","timestamp":"2026-09-04T21:38:04.469Z","sessionId":"d2bf19dc"}`
+	items, _ := ParseLine(line)
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items, got %+v", items)
+	}
+}
+
+func TestParseLine_CostState(t *testing.T) {
+	// Real shape: no timestamp field; startTime + totalDuration (ms) locate it.
+	line := `{"type":"cost-state","sessionId":"0e1f948f","totalCostUSD":13.749958700000004,"totalAPIDuration":1397557,"totalAPIDurationWithoutRetries":1397291,"totalToolDuration":850473,"totalLinesAdded":1003,"totalLinesRemoved":168,"totalDuration":58855298,"startTime":1788522122378,"modelUsage":{"claude-haiku-4-5-20251001":{"inputTokens":45592,"outputTokens":712,"costUSD":0.049152},"claude-sonnet-5":{"inputTokens":6294,"outputTokens":96305,"costUSD":1.2},"claude-opus-5":{"inputTokens":5499,"outputTokens":203056,"costUSD":12.5}},"hasUnknownModelCost":false}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeSessionEvent {
+		t.Fatalf("expected 1 session event, got %+v", items)
+	}
+	if items[0].ToolName != "session cost" {
+		t.Errorf("label = %q", items[0].ToolName)
+	}
+	want := "$13.75 · +1003/-168 lines · opus-5 sonnet-5 haiku-4-5"
+	if items[0].Content != want {
+		t.Errorf("detail = %q, want %q", items[0].Content, want)
+	}
+	wantTS := time.UnixMilli(1788522122378 + 58855298)
+	if !items[0].Timestamp.Equal(wantTS) {
+		t.Errorf("timestamp = %v, want %v", items[0].Timestamp, wantTS)
+	}
+}
+
+func TestParseLine_CostState_NoLines(t *testing.T) {
+	line := `{"type":"cost-state","sessionId":"s","totalCostUSD":1.2836649999999998,"totalLinesAdded":0,"totalLinesRemoved":0,"totalDuration":95160,"startTime":1788264806385,"modelUsage":{"claude-opus-5":{"costUSD":1.28}}}`
+	items, _ := ParseLine(line)
+	if len(items) != 1 || items[0].Content != "$1.28 · opus-5" {
+		t.Fatalf("got %+v", items)
+	}
+}
+
+func TestParseLine_CostState_EmptyDropped(t *testing.T) {
+	line := `{"type":"cost-state","sessionId":"s","totalCostUSD":0,"modelUsage":{}}`
+	items, _ := ParseLine(line)
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items, got %+v", items)
+	}
+}
+
+func TestShortModelName(t *testing.T) {
+	tests := map[string]string{
+		"claude-haiku-4-5-20251001": "haiku-4-5",
+		"claude-opus-5":             "opus-5",
+		"claude-fable-5-1":          "fable-5-1",
+		"claude-sonnet-4-5":         "sonnet-4-5",
+		"gpt-4o":                    "gpt-4o",
+	}
+	for in, want := range tests {
+		if got := shortModelName(in); got != want {
+			t.Errorf("shortModelName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseLine_TaskStatus(t *testing.T) {
+	line := `{"type":"attachment","sessionId":"s","timestamp":"2026-08-30T10:00:00Z","attachment":{"type":"task_status","taskId":"a9c1d0bd1b5243cd3","taskType":"local_agent","description":"Brainstorm next steps for Towerstakes","status":"running","deltaSummary":"Comparing rush pacing in econ/rush.go","outputFilePath":"/tmp/x.output"}}`
+	items, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Type != TypeSessionEvent {
+		t.Fatalf("expected 1 session event, got %+v", items)
+	}
+	if items[0].ToolName != "task running" {
+		t.Errorf("label = %q", items[0].ToolName)
+	}
+	want := "Brainstorm next steps for Towerstakes — Comparing rush pacing in econ/rush.go"
+	if items[0].Content != want {
+		t.Errorf("detail = %q, want %q", items[0].Content, want)
+	}
+}
+
+func TestParseLine_TaskStatus_EmptyDropped(t *testing.T) {
+	line := `{"type":"attachment","sessionId":"s","timestamp":"2026-08-30T10:00:00Z","attachment":{"type":"task_status","taskId":"x","status":"running"}}`
+	items, _ := ParseLine(line)
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items, got %+v", items)
+	}
+}
+
+// TestParseLine_NewNoiseTypesDropped pins the deliberate-drop list for line
+// types introduced in Claude Code 2.1.235–2.1.261. These are high-volume
+// bookkeeping (atis-latch alone is ~2k lines per 90 sessions) and must stay
+// out of the stream without DebugAll.
+func TestParseLine_NewNoiseTypesDropped(t *testing.T) {
+	lines := map[string]string{
+		"atis-latch":                `{"type":"atis-latch","atis":"","sessionId":"s"}`,
+		"artifact-autoreact-ledger": `{"type":"artifact-autoreact-ledger","v":1,"sessionId":"s","artifacts":{}}`,
+		"artifact-comment-monitor":  `{"type":"artifact-comment-monitor","v":1,"sessionId":"s","artifacts":{}}`,
+		"bash_output_audience_note": `{"type":"attachment","sessionId":"s","timestamp":"2026-08-30T10:00:00Z","attachment":{"type":"bash_output_audience_note","toolUseID":"toolu_01"}}`,
+		"batching_reminder_sent":    `{"type":"attachment","sessionId":"s","timestamp":"2026-08-30T10:00:00Z","attachment":{"type":"batching_reminder_sent","text":"...","model":"claude-fable-5"}}`,
+		"silent_turn_reminder":      `{"type":"attachment","sessionId":"s","timestamp":"2026-08-30T10:00:00Z","attachment":{"type":"silent_turn_reminder","text":"..."}}`,
+		"remote_session_change":     `{"type":"attachment","sessionId":"s","timestamp":"2026-08-30T10:00:00Z","attachment":{"type":"remote_session_change","url":null,"commit":"Co-Authored-By: x","pr":"y","sendUserFileHint":true}}`,
+		"plan_mode":                 `{"type":"attachment","sessionId":"s","timestamp":"2026-08-30T10:00:00Z","attachment":{"type":"plan_mode","reminderType":"full","isSubAgent":false,"planFilePath":"/x.md","planExists":false}}`,
+	}
+	for name, line := range lines {
+		t.Run(name, func(t *testing.T) {
+			items, err := ParseLine(line)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(items) != 0 {
+				t.Fatalf("expected 0 items, got %+v", items)
+			}
+		})
+	}
+}
+
+func TestFormatToolInput_NewTools(t *testing.T) {
+	tests := []struct {
+		name  string
+		tool  string
+		input string
+		want  string
+	}{
+		{"SendUserFile with caption", "SendUserFile", `{"files":["/tmp/a/review_before.png","/tmp/a/review_poses.png"],"status":"normal","caption":"Before and after"}`, "review_before.png, review_poses.png\n  # Before and after"},
+		{"SendUserFile no caption", "SendUserFile", `{"files":["/tmp/a/x.png"]}`, "x.png"},
+		{"SendUserFile caption only", "SendUserFile", `{"caption":"hi"}`, "hi"},
+		{"AskUserQuestion", "AskUserQuestion", `{"questions":[{"question":"What scope?","header":"Scope","options":[]},{"question":"Which lib?","header":"Lib"}]}`, "What scope?\nWhich lib?"},
+		{"AskUserQuestion empty falls back", "AskUserQuestion", `{"questions":[]}`, `{"questions":[]}`},
+		{"Monitor", "Monitor", `{"command":"tail -f x.log","description":"watch the log","timeout_ms":3000}`, "tail -f x.log\n  # watch the log"},
+		{"Monitor no description", "Monitor", `{"command":"tail -f x.log"}`, "tail -f x.log"},
+		{"SendMessage", "SendMessage", `{"to":"a3b166f9","message":"Nice work"}`, "→ a3b166f9: Nice work"},
+		{"SendMessage no recipient", "SendMessage", `{"message":"Nice work"}`, "Nice work"},
+		{"ListAgents", "ListAgents", `{}`, "(list agents)"},
+		{"Artifact publish", "Artifact", `{"file_path":"/tmp/s/marblemath.html","favicon":"🔵","description":"Design doc"}`, "publish /tmp/s/marblemath.html"},
+		{"Artifact redeploy to url", "Artifact", `{"file_path":"/tmp/s/m.html","url":"https://claude.ai/code/artifact/abc"}`, "publish /tmp/s/m.html → https://claude.ai/code/artifact/abc"},
+		{"Artifact read", "Artifact", `{"action":"read","url":"https://claude.ai/code/artifact/abc"}`, "read https://claude.ai/code/artifact/abc"},
+		{"Artifact list", "Artifact", `{"action":"list"}`, "list"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatToolInput(tc.tool, json.RawMessage(tc.input))
+			if got != tc.want {
+				t.Errorf("formatToolInput(%s) = %q, want %q", tc.tool, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -264,7 +264,7 @@ func (s *StreamView) renderItem(item parser.StreamItem, width int) string {
 		}
 		return mutedStyle.Render(text)
 	}
-	if item.Type == parser.TypePRLink {
+	if item.Type == parser.TypePRLink || item.Type == parser.TypeArtifactLink {
 		return mutedStyle.Render(fmt.Sprintf("── %s ──", item.Content))
 	}
 	if item.Type == parser.TypeCacheMiss {

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	version = "0.11.0"
+	version = "0.12.0"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

Claude Code 2.1.235–2.1.263 added several JSONL line types since v0.11.0 shipped. Measured against 89 local sessions from that window, four carry information worth a stream marker; the rest are pinned as deliberate drops.

**Surfaced**
- `cost-state` (CC 2.1.248) → `── session cost: $13.75 · +1003/-168 lines · opus-5 sonnet-5 haiku-4-5 ──`. Written at session end and on handoff. The line has no `timestamp`, so the event time is reconstructed from `startTime + totalDuration`. Models are listed most-expensive first with the `claude-` prefix and date suffix stripped.
- `frame-link` (CC 2.1.241) → new `TypeArtifactLink`, rendered like `pr-link`: `── artifact "MarbleMath" → https://claude.ai/code/artifact/… ──`. Count-only follow-ups (redeploys, watch bookkeeping) are dropped, surfaced only under `DEBUG_ALL`.
- `continued-in` (CC 2.1.261) → `── continued in: <successor session id> ──`.
- `attachment.task_status` → `── task running: <description> — <delta summary> ──`, a background subagent's progress note.

**Deliberately dropped** (test pins the list): `atis-latch` (~2k lines per 90 sessions, opaque token), `artifact-autoreact-ledger`, `artifact-comment-monitor`, and the `bash_output_audience_note` / `batching_reminder_sent` / `silent_turn_reminder` / `remote_session_change` / `plan_mode` attachments.

**Tool-input formatters** for `SendUserFile`, `AskUserQuestion`, `Monitor`, `SendMessage`, `ListAgents`, `Artifact`, which were falling through to raw JSON.

**No context-window change needed**: the `claude-fable-5` prefix already covers `claude-fable-5-1` (1M, CC 2.1.257).

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` (3 full runs)
- [x] 14 new parser tests: surfaced path, dropped path, DEBUG_ALL path, formatter table
- [x] Replayed real sessions carrying each new type through the parser and checked the rendered markers
- [x] Rust twin: phiat/claude-esp-rs PR for the same version

🤖 Generated with [Claude Code](https://claude.com/claude-code)